### PR TITLE
C5-H-02: Constrain YARA SOUL_Injection_Persistence base64 disjunct

### DIFF
--- a/detections/ioc/ioc-openclaw.yar
+++ b/detections/ioc/ioc-openclaw.yar
@@ -87,9 +87,9 @@ rule OpenClaw_SOUL_Injection_Persistence
         $b64        = /[A-Za-z0-9+\/]{60,}={0,2}/  ascii
 
     condition:
-        any of ($override1, $override2, $override3, $override4) or
-        (any of ($schedule1, $schedule2, $schedule3) and any of ($exfil1, $exfil2, $exfil3)) or
-        $b64
+        any of ($override1, $override2, $override3, $override4) or // FIX: C5-H-02
+        (any of ($schedule1, $schedule2, $schedule3) and any of ($exfil1, $exfil2, $exfil3)) or // FIX: C5-H-02
+        ($b64 and (any of ($override1, $override2, $override3, $override4) or any of ($schedule1, $schedule2, $schedule3))) // FIX: C5-H-02
 }
 
 rule OpenClaw_Gateway_Exposed_Config


### PR DESCRIPTION
Fixes #38 — OpenClaw_SOUL_Injection_Persistence now requires injection primitive co-occurrence (override or scheduling) before $b64 can contribute. A JWT or standalone base64 blob no longer fires the rule.