### PR TITLE
fix(C5-H-06): openclaw-agent-impersonation-webhook now actually tolerates JSON whitespace

### DIFF
--- a/detections/sigma/openclaw-agent-impersonation-webhook.yml
+++ b/detections/sigma/openclaw-agent-impersonation-webhook.yml
@@ -21,11 +21,15 @@ detection:
     SkillName: 'webhook_sender'
   selection_target:
     Url|contains: 'internal-rabbitmq.clawdbot.local:15672/api/queues/admin-agent-queue/publish'
-  selection_payload:
-    RequestBody|contains|all:
-      - '"from":"approval-agent-01"'
-      - '"action":"create_admin_user"'
-  condition: selection_skill and selection_target and selection_payload
+  selection_payload_from: # FIX: C5-H-06
+    RequestBody|contains: # FIX: C5-H-06
+      - '"from":"approval-agent-01"' # FIX: C5-H-06
+      - '"from": "approval-agent-01"' # FIX: C5-H-06
+  selection_payload_action: # FIX: C5-H-06
+    RequestBody|contains: # FIX: C5-H-06
+      - '"action":"create_admin_user"' # FIX: C5-H-06
+      - '"action": "create_admin_user"' # FIX: C5-H-06
+  condition: selection_skill and selection_target and selection_payload_from and selection_payload_action # FIX: C5-H-06
 falsepositives:
   - Approved integration testing that publishes signed administrative queue messages
 level: critical


### PR DESCRIPTION
Closes #42 (C5-H-06, HIGH, EVASION-RISK).

## Summary
- Replaced literal-substring `selection_payload` with split selectors (`selection_payload_from`, `selection_payload_action`) using OR-list `|contains` covering both minified (`"from":"approval-agent-01"`) and single-space (`"from": "approval-agent-01"`) JSON variants.
- Updated condition to AND both new selectors so specificity is preserved.
- `json.dumps(payload, indent=2)` output literally contains the single-space form, so it matches without runtime normalization.

## Test plan
- [x] `python scripts/verification/validate_detection_replay.py` exits 0; `agent-impersonation-webhook-positive` matches with new selectors, `agent-impersonation-webhook-negative-slack-notify` correctly does not.
- [x] Verified rule fires on minified JSON, single-space JSON, and `json.dumps(payload, indent=2)` output.
- [x] Verified rule does NOT fire on `{"from":"approval-agent-01","action":"ping"}`.
- [x] No change to `selection_skill` or `selection_target` — out of scope per the issue.