### PR TITLE
fix(C5-H-05): openclaw-expensive-trial-abuse now actually uses thresholds, not equality

### DIFF
--- a/detections/sigma/openclaw-expensive-trial-abuse.yml
+++ b/detections/sigma/openclaw-expensive-trial-abuse.yml
@@ -5,6 +5,7 @@ description: >
   Detects trial-account chat requests that combine the most expensive model,
   near-maximum context size, and maximum output budget. This is a replay-backed
   proxy for the scenario 007 resource exhaustion attack path.
+  Threshold values: EstimatedInputTokens >= 190000; MaxTokens >= 4000.  # FIX: C5-H-05
 references:
   - https://github.com/topazyo/openclaw-security-playbook
 author: openclaw-security-playbook
@@ -24,8 +25,8 @@ detection:
     UserTier: 'trial'
   selection_expensive:
     Model: 'claude-3-opus'
-    EstimatedInputTokens: 195000
-    MaxTokens: 4096
+    EstimatedInputTokens|gte: 190000  # FIX: C5-H-05
+    MaxTokens|gte: 4000  # FIX: C5-H-05
   condition: selection_endpoint and selection_trial and selection_expensive
 falsepositives:
   - Explicit load testing executed under a documented trial-abuse simulation

--- a/scripts/verification/validate_detection_replay.py
+++ b/scripts/verification/validate_detection_replay.py
@@ -99,6 +99,8 @@ def field_matches(event: dict[str, Any], expression: str, expected: Any) -> bool
     for modifier in modifiers:
         if modifier in {"contains", "endswith"}:
             operation = modifier
+        elif modifier in {"gte", "lte", "gt", "lt"}:  # FIX: C5-H-05
+            operation = modifier  # FIX: C5-H-05
 
     expected_values: list[Any] = cast(list[Any], expected) if isinstance(expected, list) else [expected]
 
@@ -118,6 +120,28 @@ def field_matches(event: dict[str, Any], expression: str, expected: Any) -> bool
         if require_all:
             return all(actual_text.endswith(normalize_text(str(value))) for value in expected_values)
         return any(actual_text.endswith(normalize_text(str(value))) for value in expected_values)
+
+    if operation in {"gte", "lte", "gt", "lt"}:  # FIX: C5-H-05
+        try:  # FIX: C5-H-05
+            actual_num = float(actual)  # FIX: C5-H-05
+        except (TypeError, ValueError):  # FIX: C5-H-05
+            return False  # FIX: C5-H-05
+        results: list[bool] = []  # FIX: C5-H-05
+        for value in expected_values:  # FIX: C5-H-05
+            try:  # FIX: C5-H-05
+                expected_num = float(value)  # FIX: C5-H-05
+            except (TypeError, ValueError):  # FIX: C5-H-05
+                results.append(False)  # FIX: C5-H-05
+                continue  # FIX: C5-H-05
+            if operation == "gte":  # FIX: C5-H-05
+                results.append(actual_num >= expected_num)  # FIX: C5-H-05
+            elif operation == "lte":  # FIX: C5-H-05
+                results.append(actual_num <= expected_num)  # FIX: C5-H-05
+            elif operation == "gt":  # FIX: C5-H-05
+                results.append(actual_num > expected_num)  # FIX: C5-H-05
+            else:  # operation == "lt"  # FIX: C5-H-05
+                results.append(actual_num < expected_num)  # FIX: C5-H-05
+        return all(results) if require_all else any(results)  # FIX: C5-H-05
 
     raise ValueError(f"Unsupported Sigma field modifier chain: {expression}")
 


### PR DESCRIPTION
Closes #44 (C5-H-05, HIGH, EVASION-RISK).

## Summary
- **Rule** (`detections/sigma/openclaw-expensive-trial-abuse.yml`): replaced equality with threshold semantics — `EstimatedInputTokens|gte: 190000` and `MaxTokens|gte: 4000`. Closes the 194999/4095 evasion paths the audit flagged. Description documents the new thresholds.
- **Validator** (`scripts/verification/validate_detection_replay.py`): scope expansion (orchestrator-approved) — added `gte`/`lte`/`gt`/`lt` to recognized modifiers and a numeric comparison branch in `field_matches()`. Without this, the validator silently treated unknown modifiers as `equals`, so `|gte` would have been masked as exact-match and the rule fix would not be verifiable end-to-end. Production Sigma engines support these natively.

## Threshold rationale
- `EstimatedInputTokens >= 190000`: 95% of opus's 200K context, semantically still "near-max", closes the 194999 evasion. Negative replay fixture (`enterprise-summary`) is unaffected because it matches via `selection_trial=False`.
- `MaxTokens >= 4000`: closes the 4095 evasion called out in the defect description; near-max output budget on a trial-tier opus chat call is the abuse signature.

## Test plan
- [x] AC1: rule fires at `EstimatedInputTokens=194999, MaxTokens=4096` — verified via direct `selector_matches` call.
- [x] AC2: rule fires at `200000/4096` — verified.
- [x] AC3: rule does NOT fire at `1000/512` — verified.
- [x] Edge: rule does NOT fire at `189999/4096` (just below input threshold) — verified.
- [x] Edge: rule does NOT fire at `200000/3999` (just below output threshold) — verified.
- [x] AC4: thresholds documented in rule description.
- [x] AC5: `python scripts/verification/validate_detection_rules.py` exits 0.
- [x] AC6: `python scripts/verification/validate_detection_replay.py` exits 0; `expensive-trial-abuse-positive`, `-evasion-case` both PASS, `-negative-enterprise-summary` correctly does not match. Scenario 007 coverage preserved.
- [x] No regression to other Sigma rules in the replay suite — all PASS.