### PR TITLE
Document FastAPI scope in read_only_io decorator

### DIFF
--- a/src/clawdbot/config.py
+++ b/src/clawdbot/config.py
@@ -29,44 +29,39 @@ def read_only_io(func: F) -> F:
     This decorator is a security marker to prevent accidentally exposing
     I/O-performing functions via REST GET endpoints (which must be idempotent).
 
-    If the function is called while processing an HTTP GET request, it raises
+    If the function is called while processing a Flask HTTP GET request, it raises
     `ReadOnlyIOViolation`.
+
+    **Scope limitation:** Only Flask GET context is detected. FastAPI is NOT
+    supported by this decorator and must enforce POST-only via FastAPI's own
+    route declarations (e.g. using APIRouter with explicit HTTP method constraints).
+    Do not rely on this decorator for GET-rejection in FastAPI applications.
 
     Usage:
         @read_only_io
         def my_function_that_queries_external_api():
             ...
-    """
+    """  # FIX: C5-H-07
 
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
-        # Check if we are in an HTTP GET context by looking for Flask/FastAPI
-        # request context on the call stack. If found, raise an error.
-        try:
-            # Flask detection
-            from flask import request as flask_request  # type: ignore[import-untyped]
+        # Check if we are in a Flask HTTP GET context. Raises ReadOnlyIOViolation
+        # if so. FastAPI detection is not implemented — see docstring scope note.
+        try:  # FIX: C5-H-07
+            # Flask detection only — FastAPI is explicitly out of scope
+            from flask import request as flask_request  # type: ignore[import-untyped]  # FIX: C5-H-07
 
-            if flask_request.method == "GET":
+            if flask_request.method == "GET":  # FIX: C5-H-07
                 raise ReadOnlyIOViolation(
                     f"Function {func.__name__} performs I/O and cannot be called "
                     "from an HTTP GET handler (GET must be idempotent and side-effect-free). "
                     "This is a security violation. Use POST instead."
                 )
-        except (ImportError, RuntimeError):
+        except (ImportError, RuntimeError):  # FIX: C5-H-07
             # Flask not available or not in request context, continue
             pass
 
-        try:
-            # FastAPI detection
-            from fastapi import Request  # type: ignore[import-untyped]
-
-            # FastAPI stores request in context vars, more complex to detect here.
-            # For now, rely on Flask detection; FastAPI users should wrap with
-            # explicit route handlers that enforce POST-only.
-        except ImportError:
-            pass
-
-        return func(*args, **kwargs)
+        return func(*args, **kwargs)  # FIX: C5-H-07
 
     return cast(F, wrapper)
 


### PR DESCRIPTION
Clarify that the `read_only_io` decorator only supports Flask and does not enforce restrictions for FastAPI. Update documentation to reflect this limitation and ensure users understand the need for explicit HTTP method constraints in FastAPI applications.