### PR TITLE
fix(C5-M-04,M-05): wireguard_setup.sh validates WG_INTERFACE and idempotently sets ip_forward

### DIFF
--- a/scripts/hardening/vpn/wireguard_setup.sh
+++ b/scripts/hardening/vpn/wireguard_setup.sh
@@ -388,7 +388,7 @@ configure_server() {
 
     # Validate WG_INTERFACE before heredoc interpolation to prevent injection ## FIX: C5-M-04
     if [[ ! "$WG_INTERFACE" =~ ^[a-zA-Z0-9_-]{1,15}$ ]]; then ## FIX: C5-M-04
-        echo "ERROR: WG_INTERFACE '${WG_INTERFACE}' is not a valid Linux interface name (must match ^[a-zA-Z0-9_-]{1,15}$)" >&2 ## FIX: C5-M-04
+        echo "ERROR: WG_INTERFACE must be a valid Linux interface name (1-15 alphanumeric characters, hyphens, or underscores)" >&2 ## FIX: C5-M-04
         exit 1 ## FIX: C5-M-04
     fi ## FIX: C5-M-04
 

--- a/scripts/hardening/vpn/wireguard_setup.sh
+++ b/scripts/hardening/vpn/wireguard_setup.sh
@@ -426,7 +426,11 @@ EOF
     # Enable IP forwarding
     info "Enabling IP forwarding..."
     echo 1 > /proc/sys/net/ipv4/ip_forward
-    grep -qxF 'net.ipv4.ip_forward=1' /etc/sysctl.conf || echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf  ## FIX: C5-M-05
+    # Atomically append ip_forward if absent; flock prevents races when multiple ## FIX: C5-M-05
+    # processes run concurrently, and touch ensures the file exists before grep. ## FIX: C5-M-05
+    touch /etc/sysctl.conf ## FIX: C5-M-05
+    flock /etc/sysctl.conf bash -c \ ## FIX: C5-M-05
+        'grep -qxF "net.ipv4.ip_forward=1" /etc/sysctl.conf || echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf' ## FIX: C5-M-05
     sysctl -p > /dev/null
 
     # Configure firewall

--- a/scripts/hardening/vpn/wireguard_setup.sh
+++ b/scripts/hardening/vpn/wireguard_setup.sh
@@ -386,6 +386,12 @@ configure_server() {
     local server_vpn_ip
     server_vpn_ip=$(echo "$WG_NETWORK" | sed 's|0/24|1/24|')
 
+    # Validate WG_INTERFACE before heredoc interpolation to prevent injection ## FIX: C5-M-04
+    if [[ ! "$WG_INTERFACE" =~ ^[a-zA-Z0-9_-]{1,15}$ ]]; then ## FIX: C5-M-04
+        echo "ERROR: WG_INTERFACE '${WG_INTERFACE}' is not a valid Linux interface name (must match ^[a-zA-Z0-9_-]{1,15}$)" >&2 ## FIX: C5-M-04
+        exit 1 ## FIX: C5-M-04
+    fi ## FIX: C5-M-04
+
     # Create server configuration
     info "Creating server configuration: $CONFIG_DIR/${WG_INTERFACE}.conf"
 
@@ -420,7 +426,7 @@ EOF
     # Enable IP forwarding
     info "Enabling IP forwarding..."
     echo 1 > /proc/sys/net/ipv4/ip_forward
-    echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf
+    grep -qxF 'net.ipv4.ip_forward=1' /etc/sysctl.conf || echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf  ## FIX: C5-M-05
     sysctl -p > /dev/null
 
     # Configure firewall

--- a/scripts/hardening/vpn/wireguard_setup.sh
+++ b/scripts/hardening/vpn/wireguard_setup.sh
@@ -386,12 +386,6 @@ configure_server() {
     local server_vpn_ip
     server_vpn_ip=$(echo "$WG_NETWORK" | sed 's|0/24|1/24|')
 
-    # Validate WG_INTERFACE before heredoc interpolation to prevent injection ## FIX: C5-M-04
-    if [[ ! "$WG_INTERFACE" =~ ^[a-zA-Z0-9_-]{1,15}$ ]]; then ## FIX: C5-M-04
-        echo "ERROR: WG_INTERFACE must be a valid Linux interface name (1-15 alphanumeric characters, hyphens, or underscores)" >&2 ## FIX: C5-M-04
-        exit 1 ## FIX: C5-M-04
-    fi ## FIX: C5-M-04
-
     # Create server configuration
     info "Creating server configuration: $CONFIG_DIR/${WG_INTERFACE}.conf"
 
@@ -1006,6 +1000,16 @@ For more information:
 EOF
 }
 
+# Validate WG_INTERFACE once, at script entry, before any operation runs.    ## FIX: C5-M-04
+# Called in main() after arg parsing so start/stop/configure/troubleshoot    ## FIX: C5-M-04
+# all share the same guard rather than relying on per-function checks.        ## FIX: C5-M-04
+validate_wg_interface() { ## FIX: C5-M-04
+    if [[ ! "${WG_INTERFACE}" =~ ^[a-zA-Z0-9_-]{1,15}$ ]]; then ## FIX: C5-M-04
+        echo "ERROR: WG_INTERFACE must be a valid Linux interface name (1-15 alphanumeric characters, hyphens, or underscores)" >&2 ## FIX: C5-M-04
+        exit 1 ## FIX: C5-M-04
+    fi ## FIX: C5-M-04
+} ## FIX: C5-M-04
+
 main() {
     detect_os > /dev/null
 
@@ -1083,6 +1087,8 @@ main() {
                 ;;
         esac
     done
+
+    validate_wg_interface ## FIX: C5-M-04
 
     # Print header
     print_color "$BLUE" "========================================"


### PR DESCRIPTION
M-04: Added regex guard ^[a-zA-Z0-9_-]{1,15}$ on WG_INTERFACE before heredoc interpolation — invalid values exit 1 before any config is written.

M-05: Replaced unconditional sysctl.conf append with grep -qxF guard — duplicate net.ipv4.ip_forward=1 entries can no longer accumulate across runs.