### PR TITLE
Enhance security and logging in os-scan.sh and Dockerfile

### DIFF
--- a/scripts/hardening/docker/Dockerfile.hardened
+++ b/scripts/hardening/docker/Dockerfile.hardened
@@ -142,8 +142,8 @@ FROM aquasec/trivy:0.45.0 AS scanner
 COPY --from=app-builder /opt/venv /scan/venv
 COPY --from=app-builder /build/dist /scan/dist
 
-# Run vulnerability scan
-RUN trivy filesystem --severity HIGH,CRITICAL --no-progress --exit-code 0 /scan
+# Run vulnerability scan — exit 1 on HIGH/CRITICAL findings so build fails # FIX: C5-M-09
+RUN trivy filesystem --severity HIGH,CRITICAL --no-progress --exit-code 1 /scan # FIX: C5-M-09
 
 # Generate SBOM (Software Bill of Materials)
 RUN trivy filesystem --format cyclonedx --output /scan/sbom.json /scan

--- a/scripts/vulnerability-scanning/os-scan.sh
+++ b/scripts/vulnerability-scanning/os-scan.sh
@@ -27,7 +27,7 @@ readonly NC='\033[0m' # No Color
 # Script configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_DIR
-readonly LOG_DIR="${LOG_DIR:-/var/log/openclaw}"
+LOG_DIR="${LOG_DIR:-/var/log/openclaw}" ## FIX: C5-M-07 — not readonly; must remain reassignable for fallback
 readonly REPORT_DIR="${REPORT_DIR:-${SCRIPT_DIR}/../../reports/vulnerabilities}"
 readonly TRIVY_CACHE_DIR="${HOME}/.cache/trivy"
 readonly TRIVY_VERSION="0.48.0"
@@ -121,9 +121,19 @@ check_prerequisites() {
         exit 1
     fi
     
-    # Create directories
-    mkdir -p "${LOG_DIR}" "${REPORT_DIR}" "${TRIVY_CACHE_DIR}"
-    
+    # Create directories — with explicit fallback if LOG_DIR is not writable ## FIX: C5-M-07
+    if ! mkdir -p "${LOG_DIR}" 2>/dev/null; then ## FIX: C5-M-07
+        local fallback_log_dir ## FIX: C5-M-07
+        fallback_log_dir="$(mktemp -d -t openclaw-logs.XXXXXX 2>/dev/null)" ## FIX: C5-M-07
+        if [[ -z "${fallback_log_dir}" ]] || [[ ! -d "${fallback_log_dir}" ]]; then ## FIX: C5-M-07
+            echo "[ERROR] LOG_DIR '${LOG_DIR}' is not writable and fallback temp dir creation failed — cannot continue" >&2 ## FIX: C5-M-07
+            exit 1 ## FIX: C5-M-07
+        fi ## FIX: C5-M-07
+        echo "[WARN] LOG_DIR '${LOG_DIR}' is not writable; falling back to '${fallback_log_dir}'" >&2 ## FIX: C5-M-07
+        LOG_DIR="${fallback_log_dir}" ## FIX: C5-M-07
+    fi ## FIX: C5-M-07
+    mkdir -p "${REPORT_DIR}" "${TRIVY_CACHE_DIR}"
+
     log_success "Prerequisites check passed"
 }
 

--- a/scripts/vulnerability-scanning/os-scan.sh
+++ b/scripts/vulnerability-scanning/os-scan.sh
@@ -31,9 +31,9 @@ LOG_DIR="${LOG_DIR:-/var/log/openclaw}" ## FIX: C5-M-07 — not readonly; must r
 readonly REPORT_DIR="${REPORT_DIR:-${SCRIPT_DIR}/../../reports/vulnerabilities}"
 readonly TRIVY_CACHE_DIR="${HOME}/.cache/trivy"
 readonly TRIVY_VERSION="0.48.0"
-# TODO: Set TRIVY_INSTALL_SHA256 to the known-good SHA256 for install.sh v${TRIVY_VERSION} ## FIX: C5-M-06
-# Obtain from: https://github.com/aquasecurity/trivy/releases/tag/v${TRIVY_VERSION}          ## FIX: C5-M-06
-readonly TRIVY_INSTALL_SHA256="" ## FIX: C5-M-06
+# Tarball + checksums are both fetched from the same versioned release tag.
+# No hardcoded SHA256 needed: sha256sum --check verifies the tarball against
+# the official checksums.txt from the same release. ## FIX: C5-M-06
 
 # Severity thresholds (per SEC-003 patch SLA policy)
 readonly CRITICAL_SLA_DAYS=7
@@ -145,23 +145,24 @@ install_trivy() {
     log_info "Installing Trivy ${TRIVY_VERSION}..."
     
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        # Linux installation — checksum-verified download, not curl|sh ## FIX: C5-M-06
-        if [[ -z "${TRIVY_INSTALL_SHA256}" ]]; then ## FIX: C5-M-06
-            echo "[ERROR] TRIVY_INSTALL_SHA256 not set — refusing to run unverified installer" >&2 ## FIX: C5-M-06
+        # Linux: download versioned tarball + checksums.txt from the same pinned release tag.
+        # Both URLs are version-pinned — no mutable 'main' branch involved. ## FIX: C5-M-06
+        local trivy_tarball="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" ## FIX: C5-M-06
+        local trivy_base_url="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}" ## FIX: C5-M-06
+        local trivy_checksums_file="trivy_${TRIVY_VERSION}_checksums.txt" ## FIX: C5-M-06
+
+        curl -sfL "${trivy_base_url}/${trivy_tarball}" -o "/tmp/${trivy_tarball}" ## FIX: C5-M-06
+        curl -sfL "${trivy_base_url}/${trivy_checksums_file}" -o "/tmp/${trivy_checksums_file}" ## FIX: C5-M-06
+
+        # Verify tarball against official release checksums ## FIX: C5-M-06
+        if ! (cd /tmp && grep "${trivy_tarball}" "${trivy_checksums_file}" | sha256sum --check --status); then ## FIX: C5-M-06
+            echo "[ERROR] Trivy tarball SHA256 verification failed — aborting install" >&2 ## FIX: C5-M-06
+            rm -f "/tmp/${trivy_tarball}" "/tmp/${trivy_checksums_file}" ## FIX: C5-M-06
             exit 1 ## FIX: C5-M-06
         fi ## FIX: C5-M-06
-        local trivy_install_script="/tmp/trivy-install.sh" ## FIX: C5-M-06
-        curl -sfL "https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh" \
-            -o "${trivy_install_script}" ## FIX: C5-M-06
-        local actual_sha256 ## FIX: C5-M-06
-        actual_sha256="$(sha256sum "${trivy_install_script}" | awk '{print $1}')" ## FIX: C5-M-06
-        if [[ "${actual_sha256}" != "${TRIVY_INSTALL_SHA256}" ]]; then ## FIX: C5-M-06
-            echo "[ERROR] Trivy install script SHA256 mismatch: expected ${TRIVY_INSTALL_SHA256}, got ${actual_sha256}" >&2 ## FIX: C5-M-06
-            rm -f "${trivy_install_script}" ## FIX: C5-M-06
-            exit 1 ## FIX: C5-M-06
-        fi ## FIX: C5-M-06
-        sh "${trivy_install_script}" -b /usr/local/bin "v${TRIVY_VERSION}" ## FIX: C5-M-06
-        rm -f "${trivy_install_script}" ## FIX: C5-M-06
+
+        tar -xzf "/tmp/${trivy_tarball}" -C /usr/local/bin trivy ## FIX: C5-M-06
+        rm -f "/tmp/${trivy_tarball}" "/tmp/${trivy_checksums_file}" ## FIX: C5-M-06
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         # macOS installation
         brew install aquasecurity/trivy/trivy

--- a/scripts/vulnerability-scanning/os-scan.sh
+++ b/scripts/vulnerability-scanning/os-scan.sh
@@ -31,6 +31,9 @@ LOG_DIR="${LOG_DIR:-/var/log/openclaw}" ## FIX: C5-M-07 — not readonly; must r
 readonly REPORT_DIR="${REPORT_DIR:-${SCRIPT_DIR}/../../reports/vulnerabilities}"
 readonly TRIVY_CACHE_DIR="${HOME}/.cache/trivy"
 readonly TRIVY_VERSION="0.48.0"
+# TODO: Set TRIVY_INSTALL_SHA256 to the known-good SHA256 for install.sh v${TRIVY_VERSION} ## FIX: C5-M-06
+# Obtain from: https://github.com/aquasecurity/trivy/releases/tag/v${TRIVY_VERSION}          ## FIX: C5-M-06
+readonly TRIVY_INSTALL_SHA256="" ## FIX: C5-M-06
 
 # Severity thresholds (per SEC-003 patch SLA policy)
 readonly CRITICAL_SLA_DAYS=7
@@ -142,8 +145,23 @@ install_trivy() {
     log_info "Installing Trivy ${TRIVY_VERSION}..."
     
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        # Linux installation
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v${TRIVY_VERSION}
+        # Linux installation — checksum-verified download, not curl|sh ## FIX: C5-M-06
+        if [[ -z "${TRIVY_INSTALL_SHA256}" ]]; then ## FIX: C5-M-06
+            echo "[ERROR] TRIVY_INSTALL_SHA256 not set — refusing to run unverified installer" >&2 ## FIX: C5-M-06
+            exit 1 ## FIX: C5-M-06
+        fi ## FIX: C5-M-06
+        local trivy_install_script="/tmp/trivy-install.sh" ## FIX: C5-M-06
+        curl -sfL "https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh" \
+            -o "${trivy_install_script}" ## FIX: C5-M-06
+        local actual_sha256 ## FIX: C5-M-06
+        actual_sha256="$(sha256sum "${trivy_install_script}" | awk '{print $1}')" ## FIX: C5-M-06
+        if [[ "${actual_sha256}" != "${TRIVY_INSTALL_SHA256}" ]]; then ## FIX: C5-M-06
+            echo "[ERROR] Trivy install script SHA256 mismatch: expected ${TRIVY_INSTALL_SHA256}, got ${actual_sha256}" >&2 ## FIX: C5-M-06
+            rm -f "${trivy_install_script}" ## FIX: C5-M-06
+            exit 1 ## FIX: C5-M-06
+        fi ## FIX: C5-M-06
+        sh "${trivy_install_script}" -b /usr/local/bin "v${TRIVY_VERSION}" ## FIX: C5-M-06
+        rm -f "${trivy_install_script}" ## FIX: C5-M-06
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         # macOS installation
         brew install aquasecurity/trivy/trivy

--- a/scripts/vulnerability-scanning/os-scan.sh
+++ b/scripts/vulnerability-scanning/os-scan.sh
@@ -27,7 +27,11 @@ readonly NC='\033[0m' # No Color
 # Script configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_DIR
-LOG_DIR="${LOG_DIR:-/var/log/openclaw}" ## FIX: C5-M-07 — not readonly; must remain reassignable for fallback
+# Not declared readonly: check_prerequisites() reassigns this to a temp dir    ## FIX: C5-M-07
+# if /var/log/openclaw is not writable. Bash readonly is shell-local and is    ## FIX: C5-M-07
+# never inherited by child processes, so a caller's "readonly LOG_DIR" cannot  ## FIX: C5-M-07
+# affect this script's ability to reassign the variable.                       ## FIX: C5-M-07
+LOG_DIR="${LOG_DIR:-/var/log/openclaw}" ## FIX: C5-M-07
 readonly REPORT_DIR="${REPORT_DIR:-${SCRIPT_DIR}/../../reports/vulnerabilities}"
 readonly TRIVY_CACHE_DIR="${HOME}/.cache/trivy"
 readonly TRIVY_VERSION="0.48.0"


### PR DESCRIPTION
Improve Dockerfile to fail builds on HIGH/CRITICAL vulnerabilities and enhance os-scan.sh to ensure writable log directories and verify Trivy installations with checksums. These changes increase security and reliability in the scanning process.