### PR TITLE
Refuse decompression of non-.gz paths in backup verification

### DIFF
--- a/examples/security-controls/backup-verification.py
+++ b/examples/security-controls/backup-verification.py
@@ -730,7 +730,9 @@ class DisasterRecoveryManager:
             raise ValueError(  # FIX: C5-M-03
                 f"Expected .gz backup at {backup_path!r}, got non-.gz path — refusing to decompress to avoid source overwrite"  # FIX: C5-M-03
             )  # FIX: C5-M-03
-        decompressed_path = backup_path[:-3]  # FIX: C5-M-03
+        decompressed_path = backup_path.removesuffix('.gz')  # FIX: C5-M-03
+        if not decompressed_path:  # FIX: C5-M-03
+            raise ValueError(f"backup_path {backup_path!r} has no stem before .gz — refusing to decompress")  # FIX: C5-M-03
         with open(decompressed_path, 'wb') as fh:  # FIX: C5-M-14
             result = subprocess.run(['gunzip', '-c', backup_path], stdout=fh, check=True)  # nosec  # FIX: C5-M-14
         

--- a/examples/security-controls/backup-verification.py
+++ b/examples/security-controls/backup-verification.py
@@ -726,8 +726,13 @@ class DisasterRecoveryManager:
         self.logger.info("\n[2/5] Restoring database...")
         
         # Decompress backup
-        decompressed_path = backup_path.replace('.gz', '')
-        subprocess.run(['gunzip', '-c', backup_path], stdout=open(decompressed_path, 'wb'), check=True)  # nosec
+        if not backup_path.endswith('.gz'):  # FIX: C5-M-03
+            raise ValueError(  # FIX: C5-M-03
+                f"Expected .gz backup at {backup_path!r}, got non-.gz path — refusing to decompress to avoid source overwrite"  # FIX: C5-M-03
+            )  # FIX: C5-M-03
+        decompressed_path = backup_path[:-3]  # FIX: C5-M-03
+        with open(decompressed_path, 'wb') as fh:  # FIX: C5-M-14
+            result = subprocess.run(['gunzip', '-c', backup_path], stdout=fh, check=True)  # nosec  # FIX: C5-M-14
         
         # Restore to database
         subprocess.run(  # nosec B603 B607

--- a/examples/security-controls/backup-verification.py
+++ b/examples/security-controls/backup-verification.py
@@ -734,7 +734,7 @@ class DisasterRecoveryManager:
         if not decompressed_path:  # FIX: C5-M-03
             raise ValueError(f"backup_path {backup_path!r} has no stem before .gz — refusing to decompress")  # FIX: C5-M-03
         with open(decompressed_path, 'wb') as fh:  # FIX: C5-M-14
-            result = subprocess.run(['gunzip', '-c', backup_path], stdout=fh, check=True)  # nosec  # FIX: C5-M-14
+            subprocess.run(['gunzip', '-c', backup_path], stdout=fh, check=True)  # nosec  # FIX: C5-M-14
         
         # Restore to database
         subprocess.run(  # nosec B603 B607


### PR DESCRIPTION
Prevent decompression of backup files that do not have a .gz extension to avoid accidental source overwrites. This change enhances the safety of the backup verification process.