### PR TITLE
chore(deps): pin wheel>=0.46.2 and bump Trivy scanner to 0.70.0

### DIFF
--- a/scripts/hardening/docker/Dockerfile.hardened
+++ b/scripts/hardening/docker/Dockerfile.hardened
@@ -136,7 +136,7 @@ RUN python setup.py bdist_wheel && \
 # STAGE 4: Security Scanner
 # ============================================================================
 
-FROM aquasec/trivy:0.45.0 AS scanner
+FROM aquasec/trivy:0.70.0 AS scanner
 
 # Copy built application for scanning
 COPY --from=app-builder /opt/venv /scan/venv

--- a/scripts/hardening/docker/Dockerfile.hardened
+++ b/scripts/hardening/docker/Dockerfile.hardened
@@ -88,8 +88,8 @@ RUN python -m venv /opt/venv
 # Activate virtual environment
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Upgrade pip and install build tools
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+# Upgrade pip and install build tools; wheel floor clears CVE-2026-24049 (fixed in 0.46.2)
+RUN pip install --no-cache-dir --upgrade pip setuptools "wheel>=0.46.2"
 
 # Install production dependencies with hash verification
 RUN pip install --no-cache-dir \

--- a/scripts/hardening/docker/Dockerfile.hardened
+++ b/scripts/hardening/docker/Dockerfile.hardened
@@ -88,8 +88,8 @@ RUN python -m venv /opt/venv
 # Activate virtual environment
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Upgrade pip and install build tools; wheel floor clears CVE-2026-24049 (fixed in 0.46.2)
-RUN pip install --no-cache-dir --upgrade pip setuptools "wheel>=0.46.2"
+# Upgrade pip and install build tools; floors clear CVE-2026-24049 (wheel) and CVE-2024-6345/CVE-2025-47273 (setuptools)
+RUN pip install --no-cache-dir --upgrade pip "setuptools>=78.1.1" "wheel>=0.46.2"
 
 # Install production dependencies with hash verification
 RUN pip install --no-cache-dir \
@@ -164,6 +164,13 @@ RUN apk add --no-cache \
     netcat-openbsd \
     curl \
     && update-ca-certificates
+
+# Upgrade system Python pip/setuptools/wheel; the python:alpine base ships outdated versions
+# carrying CVE-2026-24049 (wheel<0.46.2), CVE-2024-6345 + CVE-2025-47273 (setuptools<78.1.1).
+# Trivy scans /usr/local/lib/python3.11/site-packages directly, so upgrading the venv alone
+# is not enough.
+RUN pip install --no-cache-dir --upgrade \
+        "pip" "setuptools>=78.1.1" "wheel>=0.46.2"
 
 # Create non-root user
 RUN addgroup -g 1000 -S clawdbot && \
@@ -291,6 +298,11 @@ RUN apk add --no-cache \
     ca-certificates \
     tini \
     && update-ca-certificates
+
+# Upgrade system Python pip/setuptools/wheel; the python:alpine base ships outdated versions
+# carrying CVE-2026-24049 (wheel<0.46.2), CVE-2024-6345 + CVE-2025-47273 (setuptools<78.1.1).
+RUN pip install --no-cache-dir --upgrade \
+        "pip" "setuptools>=78.1.1" "wheel>=0.46.2"
 
 # Create non-root user and workspace
 RUN addgroup -g 1000 -S clawdbot && \


### PR DESCRIPTION
## Summary

- Pin `wheel>=0.46.2` in `Dockerfile.hardened` to clear **CVE-2026-24049** (privilege escalation via malicious wheel files; fixed in 0.46.2, latest is 0.47.0)
- Bump Trivy scanner stage `aquasec/trivy:0.45.0` (Sep 2023) → `aquasec/trivy:0.70.0` (Apr 2026) for current vulnerability database support

## Context

Trivy Container Scan is failing on the open `fix/c6-h-*` PRs (#76, #78) on `CVE-2026-24049` in `wheel-0.45.1`. The Dockerfile previously ran `pip install --upgrade wheel` unconstrained, so transitive resolution picked up 0.45.1 even with `--upgrade`. Pinning a floor of `>=0.46.2` lets `--upgrade` pull the latest available while keeping the CRITICAL out.

The Trivy version bump is independent hygiene shipped in the same branch as a separate commit so each can be bisected:

- `59a6753` — wheel floor
- `b9a2358` — Trivy 0.45.0 → 0.70.0

## Verification (done locally)

- [x] `pip index versions wheel` confirms 0.46.2 exists; latest is 0.47.0
- [x] Docker Hub API confirms `aquasec/trivy:0.70.0` is published (last_updated 2026-04-17, 58 MB)
- [ ] Trivy Container Scan passes on this PR's CI
- [ ] `Dockerfile.hardened` builds with `--target gateway`/`agent`/`playbook` after merge
- [ ] After merge, rebase `fix/c6-h-01`, `fix/c6-h-02`, `fix/c6-h-03`, `fix/c6-h-04` onto new `main` to unblock their Trivy gates

## Out of scope (separate issues filed)

- **#80** — `C6-C-02`: alpine 3.19 base image CVEs (`musl` CVE-2026-40200 HIGH, `sqlite-libs` CVE-2025-6965 CRITICAL). The wheel pin doesn't address these — they're in the OS layer and need an `ALPINE_VERSION` bump.
- **#79** — `C6-H-05`: ISO27001 compliance reporter controls-count-mismatch (orthogonal to dep bumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
