### PR TITLE
fix(C6-C-02): bump alpine 3.19 → 3.22 to clear 7 base-image CVEs

### DIFF
--- a/scripts/hardening/docker/Dockerfile.hardened
+++ b/scripts/hardening/docker/Dockerfile.hardened
@@ -47,7 +47,7 @@
 # ============================================================================
 
 ARG PYTHON_VERSION=3.11
-ARG ALPINE_VERSION=3.19
+ARG ALPINE_VERSION=3.22 # FIX: C6-C-02
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION=1.0.0


### PR DESCRIPTION
Closes #80.

## Summary

Bumps `ARG ALPINE_VERSION=3.19` → `ARG ALPINE_VERSION=3.22` in `Dockerfile.hardened` to clear 7 alpine-base CVEs flagged by Trivy Container Scan:

| Package       | CVE            | Severity     | Fixed in |
| ------------- | -------------- | ------------ | -------- |
| `musl`        | CVE-2025-26519 | HIGH         | r5       |
| `musl`        | CVE-2026-40200 | HIGH         | r7       |
| `musl-utils`  | CVE-2025-26519 | HIGH         | r5       |
| `musl-utils`  | CVE-2026-40200 | HIGH         | r7       |
| `sqlite-libs` | CVE-2025-6965  | **CRITICAL** | r2       |
| `sqlite-libs` | CVE-2025-29087 | HIGH         | r1       |
| `xz-libs`     | CVE-2025-31115 | HIGH         | r1       |

Single-line, surgical change.

## Why 3.22

- `python:3.11-alpine3.22` is published on Docker Hub (verified HTTP 200, last_updated 2026-04-19)
- Alpine 3.22 is current stable, longest support runway
- Alpine 3.20/3.21 would also clear these CVEs (smaller delta) — we chose 3.22 for the longer support window since this is a security playbook image

## Verification

- [x] Docker Hub tag exists (`HTTP 200` on `library/python/tags/3.11-alpine3.22`)
- [x] Single-line diff (`git diff --stat`: 1 file, 1+/1-)
- [x] Inline `# FIX: C6-C-02` tag on changed line
- [ ] Trivy Container Scan reports 0 findings for all 7 CVEs (verified by CI)
- [ ] `docker build` succeeds for `--target gateway`, `--target agent`, `--target playbook` (verified by CI)

## Out of scope

- The ISO27001 controls-count-mismatch (issue #79) is a separate finding requiring SME judgment on the missing 51 control mappings; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
