### PR TITLE
chore: clear ruff F401 + yamllint line-length on C6 session files

### DIFF
--- a/detections/sigma/openclaw-runtime-hardening-drift.yml
+++ b/detections/sigma/openclaw-runtime-hardening-drift.yml
@@ -55,7 +55,10 @@ detection:
       - "--user root" # FIX: C6-H-02
       - "--user=root" # FIX: C6-H-02
       - "--privileged" # FIX: C6-H-02
-  condition: selection_docker_run and selection_target_workload and (not (filter_cap_drop and filter_read_only and filter_user and filter_no_new_priv) or selection_negated_hardening) # FIX: C6-H-02
+  condition: >- # FIX: C6-H-02
+    selection_docker_run and selection_target_workload
+    and (not (filter_cap_drop and filter_read_only and filter_user and filter_no_new_priv)
+    or selection_negated_hardening)
 falsepositives:
   - Local development containers intentionally launched without hardening flags
 level: high

--- a/scripts/incident-response/auto-containment.py
+++ b/scripts/incident-response/auto-containment.py
@@ -38,7 +38,7 @@ import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict
 
 try:
     import boto3  # FIX: C5-finding-3


### PR DESCRIPTION
## Summary

Clears the two real linter findings on files touched during the Cycle 6 fix session. No functional changes.

| Linter               | File                                                       | Issue                                  | Fix                               |
| -------------------- | ---------------------------------------------------------- | -------------------------------------- | --------------------------------- |
| ruff F401            | `scripts/incident-response/auto-containment.py:41`         | `typing.List` imported but unused      | Remove `List` from import line    |
| yamllint line-length | `detections/sigma/openclaw-runtime-hardening-drift.yml:58` | `condition:` line was 197 chars (>120) | Wrap with YAML folded scalar `>-` |

CRLF line endings on the Sigma rule were also present (worker wrote on Windows during C6-H-02); converted to LF before wrapping, but git's `core.autocrlf=true` normalizes those out of the diff. Net effect: only the four-line `condition:` block changes.

## Verification done locally

- [x] `ruff check` on all 3 touched Python files: clean
- [x] `yamllint detections/sigma/openclaw-runtime-hardening-drift.yml`: clean
- [x] Parsed YAML `condition` string is **byte-identical** to the pre-wrap version (folded scalar with same-indent continuations folds newlines to single spaces): `assert cond == expected` → True
- [x] `validate_detection_replay.py --skip-yara`: all 4 C6-H-02 evasion fixtures still match the rule (`runtime-hardening-drift-evasion-{readonly-false,capadd-sysadmin,nonewprivileges-false,user-zero}`)
- [x] `pytest tests/integration/test_modified_function_claims.py`: 16/16 pass

## Out of scope (intentional)

- **Pyright found 30 errors** on touched Python files — all on lines this session did not modify (test-harness module-attribute assignments, pre-existing `reportArgumentType` errors at `auto-containment.py:232/241/360/489`, etc.). Treating as pre-existing tech debt; would need a separate dedicated PR.
- **No shellcheck/hadolint** locally (not installed); CI's shellcheck already passed for `verify_openclaw_security.sh` during this session's PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
