### PR TITLE
fix(C6-H-06): compliance gate heredoc EOF terminates so step exits cleanly

### DIFF
--- a/.github/workflows/compliance-check.yml
+++ b/.github/workflows/compliance-check.yml
@@ -152,12 +152,12 @@ jobs:
           import json
           import sys
           import os
-          
+
           # Check for SOC2 report
           if not os.path.exists('soc2-report.json'):
             print("❌ Error: soc2-report.json not found", file=sys.stderr)
             sys.exit(1)
-          
+
           try:
             with open('soc2-report.json') as f:
               soc2_report = json.load(f)
@@ -168,12 +168,12 @@ jobs:
           except json.JSONDecodeError as e:
             print(f"❌ Error: Invalid JSON in soc2-report.json: {e}", file=sys.stderr)
             sys.exit(1)
-          
+
           # Check for ISO27001 report
           if not os.path.exists('iso27001-report.json'):
             print("❌ Error: iso27001-report.json not found", file=sys.stderr)
             sys.exit(1)
-          
+
           try:
             with open('iso27001-report.json') as f:
               iso_report = json.load(f)
@@ -184,7 +184,7 @@ jobs:
           except json.JSONDecodeError as e:
             print(f"❌ Error: Invalid JSON in iso27001-report.json: {e}", file=sys.stderr)
             sys.exit(1)
-          
+
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
             f.write(f"soc2_percentage={soc2_percentage}\n")
             f.write(f"iso27001_percentage={iso27001_percentage}\n")
@@ -265,4 +265,5 @@ jobs:
               print(f"✅ SOC2 ({soc2}%) and ISO27001 ({iso27001}%) both meet the 95% threshold")  # FIX: C5-H-10
           else:  # FIX: C5-H-10
               sys.exit(1)  # FIX: C5-H-10
-          EOF  # FIX: C5-H-10
+          # FIX: C6-H-06: terminator must be bare EOF with no trailing content so bash closes the heredoc
+          EOF


### PR DESCRIPTION
## Summary
- Closes #86 — the `Fail if compliance below 95%` step had a trailing `# FIX: C5-H-10` inline comment on the heredoc terminator line. After YAML common-indent stripping, bash saw `EOF  # FIX: C5-H-10` instead of bare `EOF` and never closed the heredoc.
- Symptom: Python printed the success line, then crashed on `NameError: name 'EOF' is not defined`. The step exited 1 even when both SOC2 and ISO27001 met the 95% threshold (bug was masked until C6-H-05 fixed the predecessor step that was failing first).
- Moved the FIX tag onto its own line above the terminator so the rendered shell sees a bare `EOF` at column 0. The tag line becomes a Python `#` comment inside the heredoc body (no-op).

## Test plan
- [x] Workflow YAML parses (`yaml.safe_load` with `encoding='utf-8'`)
- [x] End-to-end bash execution of the rendered step against three synthetic input pairs:
  - Green (SOC2=100, ISO=100) → exit 0, `✅ ... both meet the 95% threshold`, no `NameError`, no `delimited by end-of-file` warning
  - Red SOC2 (90, 100) → exit 1, `❌ SOC2 below 95% (got 90.0%)`
  - Red ISO (100, 80) → exit 1, `❌ ISO27001 below 95% (got 80.0%)`
- [x] Existing `# FIX: C5-H-10` tags preserved on unmodified lines

Fixes #86