### PR TITLE
fix(C6-M-??): compliance-check.yml triggers on reporter script changes

### DIFF
--- a/.github/workflows/compliance-check.yml
+++ b/.github/workflows/compliance-check.yml
@@ -9,6 +9,9 @@ on:
       - "configs/**"
       - "docs/policies/**"
       - "configs/organization-policies/**"
+      - "tools/compliance-reporter.py" # FIX: C6-M-??
+      - "tools/compliance-data/**" # FIX: C6-M-??
+      - ".github/workflows/compliance-check.yml" # FIX: C6-M-??
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Closes #87 — `on.pull_request.paths` triggered only on `configs/**`, `docs/policies/**`, `configs/organization-policies/**`. Changes to `tools/compliance-reporter.py` (the script the workflow actually executes) did not trigger the gate, so a regression in the reporter would not be caught at PR time. Discovered when PR #85 (C6-H-05) modified the reporter but the gate did not run.
- Adds three path entries:
  - `tools/compliance-reporter.py` — the executor
  - `tools/compliance-data/**` — future-proofing for compliance data dir
  - `.github/workflows/compliance-check.yml` — workflow self-test on its own edits (catches regressions like the just-fixed C6-H-06 heredoc bug before merge instead of post-merge)
- Each added line tagged `# FIX: C6-M-??`.

## Test plan
- [x] Workflow YAML parses (`yaml.safe_load` with `encoding='utf-8'`)
- [x] Existing trigger paths preserved (`configs/**`, `docs/policies/**`, `configs/organization-policies/**`)
- [ ] A future PR modifying only `tools/compliance-reporter.py` will trigger `compliance-check.yml`
- [ ] A future PR modifying only `.github/workflows/compliance-check.yml` will trigger it (workflow self-test)

Builds on #88 (C6-H-06 heredoc fix, merged) — with that landed, the broader trigger surface is safe to enable.

Fixes #87