### PR TITLE
fix(C5-H-06): collect_evidence.sh --containment claim now matches actual behavior

### DIFF
--- a/docs/guides/06-incident-response.md
+++ b/docs/guides/06-incident-response.md
@@ -17,18 +17,22 @@ This guide provides actionable incident response playbooks for AI agent security
 
 > **Document type — Learning Guide**  
 > This is the educational reference guide covering incident response concepts, classification, and example response patterns. It is intentionally self-contained for learning purposes.
+>
 > - **Operational runbook** (emergency contacts, escalation matrix, SLAs, and playbook index): see [docs/procedures/incident-response.md](../procedures/incident-response.md).
 > - **Standalone executable playbooks** (IRP-001 – IRP-004, with full dependency notices): see [examples/incident-response/](../../examples/incident-response/).
 
 ## Platform Notes
 
 ### Linux
+
 Use commands as written for Docker, `iptables`, and forensic collection.
 
 ### macOS
+
 Prefer equivalent `pf`/system tooling where Linux-specific networking commands differ.
 
 ### Windows
+
 Use PowerShell equivalents and WSL2 where bash-oriented commands are required.
 
 ## Table of Contents
@@ -49,12 +53,12 @@ Use PowerShell equivalents and WSL2 where bash-oriented commands are required.
 
 ### Severity Levels
 
-| Level | Description | Response Time | Examples |
-|-------|-------------|---------------|----------|
-| **P0 - Critical** | Active exploitation, data exfiltration | Immediate (5 min) | Credentials being exfiltrated, ongoing breach |
-| **P1 - High** | High risk of exploitation, system compromise | 15 minutes | Malicious skill detected, unauthorized access attempts |
-| **P2 - Medium** | Potential security weakness, no active exploit | 1 hour | Configuration drift, missing security controls |
-| **P3 - Low** | Security hygiene, best practice violations | 1 business day | Outdated dependencies, log gaps |
+| Level             | Description                                    | Response Time     | Examples                                               |
+| ----------------- | ---------------------------------------------- | ----------------- | ------------------------------------------------------ |
+| **P0 - Critical** | Active exploitation, data exfiltration         | Immediate (5 min) | Credentials being exfiltrated, ongoing breach          |
+| **P1 - High**     | High risk of exploitation, system compromise   | 15 minutes        | Malicious skill detected, unauthorized access attempts |
+| **P2 - Medium**   | Potential security weakness, no active exploit | 1 hour            | Configuration drift, missing security controls         |
+| **P3 - Low**      | Security hygiene, best practice violations     | 1 business day    | Outdated dependencies, log gaps                        |
 
 ### Incident Types
 
@@ -69,6 +73,7 @@ Use PowerShell equivalents and WSL2 where bash-oriented commands are required.
 ## Playbook 1: Credential Exfiltration
 
 ### Symptoms
+
 - Alert: "Skill sent data to non-whitelisted endpoint"
 - Unusual API usage patterns
 - Network traffic to unknown IPs
@@ -76,6 +81,7 @@ Use PowerShell equivalents and WSL2 where bash-oriented commands are required.
 ### Phase 1: Containment (5-10 minutes)
 
 #### Step 1.1: Isolate the Agent
+
 ```bash
 # Stop ClawdBot immediately
 docker stop clawdbot-production
@@ -85,6 +91,7 @@ ps aux | grep -i claw
 ```
 
 #### Step 1.2: Block Network Access
+
 ```bash
 # Block all traffic
 sudo iptables -I INPUT -s <AGENT_IP> -j DROP
@@ -92,6 +99,7 @@ sudo iptables -I OUTPUT -d <AGENT_IP> -j DROP
 ```
 
 #### Step 1.3: Revoke Credentials
+
 - Anthropic: https://console.anthropic.com/settings/keys
 - OpenAI: https://platform.openai.com/api-keys
 - AWS: IAM Console
@@ -137,6 +145,7 @@ docker start clawdbot-production
 ## Playbook 2: Prompt Injection Attack
 
 ### Symptoms
+
 - Agent performs unexpected actions
 - Tool execution logs show suspicious commands
 - Alert: "Potential prompt injection detected"
@@ -194,6 +203,7 @@ shield:
 ## Playbook 3: Unauthorized Network Access
 
 ### Symptoms
+
 - Alert: "Gateway accessed from non-VPN IP"
 - Failed authentication from unexpected source
 
@@ -224,6 +234,7 @@ jq 'select(.source_ip=="<ATTACKER_IP>" and .auth_status=="success")' \
 ## Playbook 4: Malicious Skill Installation
 
 ### Symptoms
+
 - Alert: "Skill integrity check failed"
 - New skill appears in directory
 
@@ -268,23 +279,39 @@ git clone https://github.com/anthropic-ai/openclaw-skills ~/.openclaw/skills
 
 ## Evidence Collection
 
+<!-- FIX: C5-H-06 -->
+
 ### Automated Evidence Collection Script
 
 ```bash
 # Use the canonical collection script from this repository
 ./scripts/forensics/collect_evidence.sh
 
-# Optional: collect evidence and then run containment
+# Optional: after collection, attempt to stop the agent's services/containers
+# (moltbot + openclaw via systemctl, clawdbot via docker). Does NOT block
+# network traffic — apply iptables/ufw rules separately if needed
+# (see Playbook 1 Step 1.2 above).
 ./scripts/forensics/collect_evidence.sh --containment
 ```
 
-**Verify:** Expected output:
+**Verify:** Successful run (no critical findings, no warnings) — exit code `0`:
+
 ```text
-Evidence collection complete: /home/<user>/openclaw-incident-YYYYMMDD-HHMMSS
-Next steps:
+============================================================
+ Evidence collection complete: /home/<user>/openclaw-incident-YYYYMMDD-HHMMSS
+============================================================
+
+ Next steps:
   1. Review SOUL.md files for injected instructions
   2. Check hash chain report for log tampering
+  3. If backup credential files found: rotate at providers FIRST
+  4. Run build_timeline.sh to reconstruct attack sequence
+  5. Run check_credential_scope.sh to assess what was exposed
 ```
+
+With `--containment` on a host without the named systemd/docker services,
+expect warnings and exit code `2` — that is the script's honest signal that
+the services it tried to stop were absent.
 
 ---
 
@@ -338,6 +365,7 @@ Date: [Date]
 Attendees: [Names]
 
 ## Incident Summary
+
 - Type: [Type]
 - Severity: P[0-3]
 - Duration: [Hours]
@@ -345,32 +373,36 @@ Attendees: [Names]
 
 ## Timeline
 
-| Time | Event | Action | By Whom |
-|------|-------|--------|---------|
-| 01:30 | Alert | Acknowledged | John |
-| 01:35 | Containment | Stopped agent | John |
+| Time  | Event       | Action        | By Whom |
+| ----- | ----------- | ------------- | ------- |
+| 01:30 | Alert       | Acknowledged  | John    |
+| 01:35 | Containment | Stopped agent | John    |
 
 ## What Went Well
+
 - Alert fired promptly
 - Runbook was clear
 - Fast containment
 
 ## What Went Wrong
+
 - Root cause identification took too long
 - No automated rollback
 - Manual evidence collection
 
 ## Root Cause
+
 [Detailed explanation]
 
 ## Action Items
 
-| Action | Owner | Due Date | Priority |
-|--------|-------|----------|----------|
-| Deploy shield | DevOps | 2026-02-16 | P0 |
-| Automated rollback | Eng | 2026-02-20 | P1 |
+| Action             | Owner  | Due Date   | Priority |
+| ------------------ | ------ | ---------- | -------- |
+| Deploy shield      | DevOps | 2026-02-16 | P0       |
+| Automated rollback | Eng    | 2026-02-20 | P1       |
 
 ## Metrics
+
 - Time to Detect: 2 min
 - Time to Contain: 10 min
 - Time to Resolve: 90 min

--- a/scripts/forensics/collect_evidence.sh
+++ b/scripts/forensics/collect_evidence.sh
@@ -2,7 +2,12 @@
 # collect_evidence.sh — OpenClaw Incident Evidence Preservation
 #
 # USAGE: ./collect_evidence.sh [--containment]
-#   --containment: Also stop the agent and block network after evidence collection
+#   --containment: After evidence collection, attempt to stop the agent's       ## FIX: C5-H-06
+#                  services/containers (moltbot + openclaw via systemctl,       ## FIX: C5-H-06
+#                  clawdbot via docker). Does NOT block network traffic —       ## FIX: C5-H-06
+#                  apply iptables/ufw rules separately if network containment   ## FIX: C5-H-06
+#                  is required (see docs/guides/06-incident-response.md         ## FIX: C5-H-06
+#                  Playbook 1 Step 1.2).                                        ## FIX: C5-H-06
 #
 # Run this BEFORE stopping the agent process to preserve in-memory state.
 # Part of: https://github.com/topazyo/openclaw-security-playbook
@@ -23,13 +28,18 @@ Usage:
   ./scripts/forensics/collect_evidence.sh [--containment] [--help|-h]
 
 Options:
-  --containment   Also stop agent services after evidence collection
+  --containment   After evidence collection, attempt to stop the moltbot and
+                  openclaw systemd services and the clawdbot Docker container.
+                  Each stop attempt that fails is recorded as a warning. Does
+                  NOT block network traffic — apply iptables/ufw separately
+                  if network containment is required.
   --help, -h      Show this help message and exit
 
 Exit codes:
     0  Successful execution (no critical issues, no warnings)
     1  Critical findings detected during collection
-    2  Warnings detected or invalid arguments
+    2  Warnings detected (including failed containment commands) or invalid
+       arguments
 
 Run this before stopping the agent process to preserve volatile state.
 EOF
@@ -230,7 +240,8 @@ echo "  5. Run check_credential_scope.sh to assess what was exposed"
 echo ""
 
 if [ "${CONTAINMENT}" = true ]; then
-    echo "[+] Running containment (--containment flag set)..."
+    echo "[+] Running containment (--containment flag set)..."                  ## FIX: C5-H-06
+    echo "    Note: stops services/containers only — does NOT block network."  ## FIX: C5-H-06
     if ! systemctl stop moltbot 2>/dev/null; then
         record_warning "Failed to stop moltbot during containment"
     fi
@@ -240,7 +251,7 @@ if [ "${CONTAINMENT}" = true ]; then
     if ! docker stop clawdbot 2>/dev/null; then
         record_warning "Failed to stop clawdbot during containment"
     fi
-    echo "    Agent stopped."
+    echo "    Containment step finished (service/container stop attempted)."   ## FIX: C5-H-06
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
Addresses C5-H-06 (originally tracked in #20, which was closed prematurely — the fix on `topazyo/issue20` never landed on main).

`scripts/forensics/collect_evidence.sh` claimed in three places that `--containment` "blocks network" after evidence collection:
- Header docstring (line 5)
- `print_help` output (`--containment` option description)
- Runtime echo `"Agent stopped."` after the containment block

The implementation only stops services/containers — `systemctl stop moltbot`, `systemctl stop openclaw`, `docker stop clawdbot`. No `iptables`, no `ufw`, no firewall manipulation of any kind.

## What changed
- **scripts/forensics/collect_evidence.sh** (4 surgical edits, tagged `## FIX: C5-H-06`):
  - Header `--containment` description now explicitly says "Does NOT block network traffic" and points operators to `iptables`/`ufw` separately (Playbook 1 Step 1.2 in the guide).
  - `print_help` `--containment` description matches.
  - Added a `Note:` echo right before the stop commands clarifying scope.
  - Replaced `"Agent stopped."` with `"Containment step finished (service/container stop attempted)."` — honest about partial successes.
- **docs/guides/06-incident-response.md** Evidence Collection section: sample output now reflects the real banner + summary block; documents that `--containment` on a host missing the named services produces exit code 2 by design.

> Note: the doc file also shows many incidental blank-line-after-heading and table-padding changes — that is the local markdownlint pre-commit hook auto-formatting the file when I edited it. Non-semantic.

## Why not the broader `1579b0f` from `topazyo/issue20`
That commit conflates the C5-H-06 fix with a markdown-wide reformatting sweep AND deletes C6 work (e.g., `tests/unit/test_compliance_reporter_iso27001.py`, −341 lines from C6-H-05). Merging it as-is would regress most of Cycle 6.

## Test plan
- [x] `bash -n scripts/forensics/collect_evidence.sh` — clean
- [x] Diff review: only the three claim surfaces in the script + Evidence Collection section in the doc carry semantic changes
- [ ] Lint CI passes
- [ ] Reviewer spot-checks the docstring matches the implementation's actual scope

Manually re-opens & closes #20.