### PR TITLE
Fix redundant Exception in docker-init except clause

### DIFF
--- a/scripts/incident-response/auto-containment.py
+++ b/scripts/incident-response/auto-containment.py
@@ -92,7 +92,7 @@ class ContainmentManager:
         if docker is not None:  # FIX: C5-finding-3
             try:
                 self.docker_client = docker.from_env()  # FIX: C5-finding-3
-            except (docker.errors.DockerException, OSError, Exception) as e:  # FIX: C5-M-02
+            except (docker.errors.DockerException, OSError) as e:  # FIX: C6-M-03
                 self.docker_client = None  # FIX: C5-M-02
                 self.log_action("init_docker_client", "self", "FAIL", {"error": str(e)})  # FIX: C5-M-02
                 logger.warning("Docker not available: %s", e)  # FIX: C5-M-02


### PR DESCRIPTION
Remove the redundant `Exception` from the except clause in `auto-containment.py` to streamline error handling.