### PR TITLE
fix(C6-H-08): save_manifest now writes CHECKSUMS.txt even when manifest has degraded/failed items lacking checksum_sha256

### DIFF
--- a/scripts/incident-response/forensics-collector.py
+++ b/scripts/incident-response/forensics-collector.py
@@ -429,7 +429,11 @@ class ForensicsCollector:
             f.write("# Evidence Items\n")
             
             for item in self.manifest["evidence_items"]:
-                f.write(f"{item['checksum_sha256']}  {item['file_path']}\n")
+                if item.get("status") in ("degraded", "failed") or item.get("file_path") is None:  # FIX: C6-H-08
+                    detail = item.get("reason") or item.get("description") or "no detail"  # FIX: C6-H-08
+                    f.write(f"# DEGRADED  {item.get('name', 'unnamed')}: {detail}\n")  # FIX: C6-H-08
+                    continue  # FIX: C6-H-08
+                f.write(f"{item.get('checksum_sha256', 'N/A')}  {item.get('file_path', 'N/A')}\n")  # FIX: C6-H-08
         
         logger.info(f"✓ Chain of custody manifest saved: {manifest_file}")
         logger.info(f"✓ Checksums saved: {checksum_file}")

--- a/tests/integration/test_modified_function_claims.py
+++ b/tests/integration/test_modified_function_claims.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import json
+import re
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -258,6 +259,38 @@ def test_isolate_container_claim_isolates_documented_container(tmp_path):
     no_docker_manager = ctx.module.ContainmentManager("INC-NODOCKER")
     no_docker_manager.docker_client = None
     assert no_docker_manager.isolate_container("agent-prod-42", reason="Missing Docker") is False
+
+
+def test_C6_H_08_save_manifest_does_not_crash_on_degraded_evidence_items(tmp_path):  # FIX: C6-H-08
+    """Locks the C6-H-08 claim: save_manifest must emit CHECKSUMS.txt successfully
+    even when manifest contains degraded items lacking checksum_sha256/file_path."""
+    module = _load_forensics_collector_module("forensics_collector_claim_c6_h_08_save_manifest")  # FIX: C6-H-08
+    inst = module.ForensicsCollector("INC-TEST-C6H08", level="standard")  # FIX: C6-H-08
+    inst.evidence_dir = tmp_path / "evidence"  # FIX: C6-H-08
+    inst.evidence_dir.mkdir(parents=True, exist_ok=True)  # FIX: C6-H-08
+    inst.manifest["evidence_items"].append({  # FIX: C6-H-08
+        "name": "log_collection_degraded",  # FIX: C6-H-08
+        "file_path": None,  # FIX: C6-H-08
+        "description": "no log source available on host",  # FIX: C6-H-08
+        "status": "degraded",  # FIX: C6-H-08
+        "reason": "neither journalctl nor LOG_DIR is available",  # FIX: C6-H-08
+    })  # FIX: C6-H-08
+
+    inst.save_manifest()  # FIX: C6-H-08 — must not raise KeyError
+
+    checksums_path = inst.evidence_dir / "CHECKSUMS.txt"  # FIX: C6-H-08
+    manifest_path = inst.evidence_dir / "chain-of-custody.json"  # FIX: C6-H-08
+    assert checksums_path.exists(), "CHECKSUMS.txt was not written"  # FIX: C6-H-08
+    assert manifest_path.exists(), "chain-of-custody.json was not written"  # FIX: C6-H-08
+    checksums_content = checksums_path.read_text(encoding="utf-8")  # FIX: C6-H-08
+    assert "# DEGRADED  log_collection_degraded" in checksums_content, checksums_content  # FIX: C6-H-08
+    # Negative assertion: no SHA-256 checksum line for the degraded item exists  # FIX: C6-H-08
+    bad_checksum = re.compile(r"^[0-9a-fA-F]{64}\s+log_collection_degraded\s*$", re.MULTILINE)  # FIX: C6-H-08
+    assert not bad_checksum.search(checksums_content), (  # FIX: C6-H-08
+        "save_manifest emitted an invalid checksum line for a degraded item; "  # FIX: C6-H-08
+        "the `continue` at L435 of forensics-collector.py is not guarding the "  # FIX: C6-H-08
+        f"sha256sum-style line. Output was:\n{checksums_content}"  # FIX: C6-H-08
+    )  # FIX: C6-H-08
 
 
 def test_update_rate_limits_claim_writes_emergency_override_profile(tmp_path):


### PR DESCRIPTION
## Summary

Fixes audit finding **C6-H-08** ([issue #92 covers a similar but distinct finding C6-H-07](https://github.com/topazyo/openclaw-security-playbook/issues/92); C6-H-08 was discovered after that one and went straight to implementation).

`ForensicsCollector.save_manifest()` previously crashed with `KeyError: 'checksum_sha256'` whenever the manifest contained any item appended by the degraded paths in `collect_logs` (C6-M-04, L356-365) or `collect_network_capture` (C5-M-04, L383-390 and L413-420). Those items have `file_path: None` and no `checksum_sha256` key — so an incident with degraded log or pcap collection lost its entire chain-of-custody write.

## Fix

The for-loop at L445-446 now:
- Skips items with `status in ("degraded", "failed")` or `file_path is None`, emitting a `# DEGRADED  <name>: <reason>` line that's still valid checksum-file syntax (`sha256sum -c` ignores `#` lines)
- Defensively uses `.get()` for `checksum_sha256` / `file_path` so future degraded shapes don't crash either

Every modified line carries ` # FIX: C6-H-08`.

## Test plan

- [x] New regression test `test_C6_H_08_save_manifest_does_not_crash_on_degraded_evidence_items` in `tests/integration/test_modified_function_claims.py` — appends a degraded item by hand, calls `save_manifest()`, asserts no exception and that the `# DEGRADED` line appears in `CHECKSUMS.txt`
- [x] Full `test_modified_function_claims.py` suite: 17 passed (16 prior + new one)
- [x] Smoke: forced degraded path produces `CHECKSUMS.txt` containing `# DEGRADED  log_collection_degraded` and `chain-of-custody.json` is written