### PR TITLE
fix(C6-M-06): skill_integrity_monitor.sh restore_skill now preserves paths containing spaces

### DIFF
--- a/scripts/supply-chain/skill_integrity_monitor.sh
+++ b/scripts/supply-chain/skill_integrity_monitor.sh
@@ -698,9 +698,9 @@ restore_skill() {
 
     info "Restoring skill: $quarantine_id"
 
-    # Read original path
+    # Read original path — awk extracts everything after the 3rd field so paths with spaces round-trip ## FIX: C6-M-06
     local original_path
-    original_path=$(grep "Original Path:" "${quarantine_path}/QUARANTINE_INFO.txt" | cut -d' ' -f3)
+    original_path=$(awk '/^Original Path:/ { $1=$2=""; sub(/^[[:space:]]+/, ""); print }' "${quarantine_path}/QUARANTINE_INFO.txt") ## FIX: C6-M-06
 
     if [ -z "$original_path" ]; then
         error "Could not determine original path"


### PR DESCRIPTION
## Summary

Fixes audit finding **C6-M-06** (part of [issue #74 — C6-M-Batch-C](https://github.com/topazyo/openclaw-security-playbook/issues/74)).

`skill_integrity_monitor.sh restore_skill` extracted the quarantined skill's original path with `grep | cut -d' ' -f3`. For a metadata line like `Original Path: /opt/my skill/dir`, `cut -d' ' -f3` yields only `/opt/my` — silently corrupting the restore destination for any path containing a space.

## Fix

Replaced the fragile `cut`-based extraction with `awk` that strips the first two fields (`Original` and `Path:`) plus leading whitespace, preserving the rest of the line verbatim including embedded spaces:

```bash
awk '/^Original Path:/ { $1=$2=""; sub(/^[[:space:]]+/, ""); print }'
```

Every modified line carries `## FIX: C6-M-06`.

## Test plan

- [x] Round-trip verification: `/tmp/c6m06 test/skill` (path with space) quarantined and restored returns the same path
- [x] Single-word path paths still round-trip (existing test coverage preserved)
- [x] No change to the signature/quarantine flow proper (C5-H verified)

## Out of scope

- The `--quarantine` flow itself (verified C5)
- Any other check inside `skill_integrity_monitor.sh`
- Any related supply-chain script