### PR TITLE
fix(C6-M-08): compliance-reporter.py generate_report now raises on unknown framework

### DIFF
--- a/tools/compliance-reporter.py
+++ b/tools/compliance-reporter.py
@@ -235,7 +235,27 @@ class ComplianceReporter:
         return controls
     
     def generate_report(self, framework: str = "SOC2") -> ComplianceReport:  # FIX: C5-finding-4
-        """Generate compliance report for specified framework."""
+        """Generate compliance report for specified framework.
+
+        Returns:
+            ComplianceReport (``dict[str, Any]``) with at least the following keys:
+                - ``framework`` (str): canonical name — ``"SOC 2 Type II"``,
+                  ``"ISO 27001:2022"``, or ``"GDPR"``
+                - ``generated_at`` (str): ISO 8601 UTC timestamp
+                - ``controls`` (list[ControlRecord]): per-control status records
+                - ``implemented_count`` (int): count of fully-implemented controls
+                - ``pending_count`` (int): count of non-implemented controls
+                - ``compliance_percentage`` (float): implemented / total * 100
+            ISO 27001 reports include two additional keys (added by C6-H-05):
+                - ``compliance_percentage_basis`` (str): always ``"loaded_corpus"``
+                - ``coverage_summary`` (dict): per-control-family coverage details
+
+        Raises:
+            ValueError: If ``framework`` is not one of ``"SOC2"``, ``"ISO27001"``,
+                or ``"GDPR"``. The module's CLI handler catches ``ValueError`` and
+                exits with code 2; programmatic callers must handle the exception
+                explicitly — the function no longer returns an error dict.
+        """  # FIX: C6-M-08
         if framework == "SOC2":
             return self._generate_soc2_report()
         elif framework == "ISO27001":
@@ -243,7 +263,7 @@ class ComplianceReporter:
         elif framework == "GDPR":
             return self._generate_gdpr_report()
         else:
-            return {"error": f"Unknown framework: {framework}"}
+            raise ValueError(f"Unknown framework: {framework}")  # FIX: C6-M-08
     
     def _generate_soc2_report(self) -> ComplianceReport:  # FIX: C5-finding-4
         """Generate SOC 2 compliance report."""


### PR DESCRIPTION
## Summary

Fixes audit finding **C6-M-08** (part of [issue #74 — C6-M-Batch-C](https://github.com/topazyo/openclaw-security-playbook/issues/74)).

`ComplianceReporter.generate_report` previously returned `{"error": f"Unknown framework: {framework}"}` for an unrecognized framework string. The CLI catches `(FileNotFoundError, json.JSONDecodeError, OSError, ValueError) → SystemExit(2)` — but the dict return doesn't raise, so the CLI prints the error dict as JSON and exits **0**. argparse `choices=` blocks `--framework FOO` at the command-line, but the Python API (`ComplianceReporter().generate_report("FOO")`) silently returned an error dict.

## Fix

`generate_report` now raises `ValueError(f"Unknown framework: {framework}")` instead of returning a dict. The existing CLI handler catches `ValueError` → `SystemExit(2)`, so the script now exits nonzero on bad input as documented.

Docstring expanded with `Returns:` and `Raises:` sections so callers know the exception contract:

```python
def generate_report(self, framework: str = "SOC2") -> ComplianceReport:
    """Generate compliance report for specified framework.

    Returns:
        ComplianceReport (``dict[str, Any]``) with at least the following keys:
            - ``framework`` (str): canonical name
            - ``generated_at`` (str): ISO 8601 UTC timestamp
            - ``controls`` (list[ControlRecord])
            - ``implemented_count`` / ``pending_count`` (int)
            - ``compliance_percentage`` (float)
        ISO 27001 reports include two additional keys (from C6-H-05):
            - ``compliance_percentage_basis`` / ``coverage_summary``

    Raises:
        ValueError: If ``framework`` is not one of SOC2, ISO27001, or GDPR.
    """  # FIX: C6-M-08
```

Every modified line carries `# FIX: C6-M-08`.

## Test plan

- [x] `ComplianceReporter().generate_report("NONESUCH")` → `ValueError: Unknown framework: NONESUCH`
- [x] CLI invocation with valid framework (`--framework SOC2`) still exits 0 with a report
- [x] CLI invocation with an invalid framework is blocked by argparse `choices=` (pre-existing)
- [x] Programmatic invocation with unknown framework now raises (previously returned silent error dict)
- [x] `tests/unit/test_compliance_reporter_iso27001.py` — 10/10 passed

## Out of scope

One follow-up surfaced by Copilot during this PR's review and filed separately:

- **#98 (C6-M-13)** — `_build_iso27001_coverage_summary` returns `0.0` for `corpus_to_soa_coverage_percentage` when `soa_applicable=0 AND mapped>0`, contradicting the `gap_status: "OVER_MAPPING"` reported alongside. From C6-H-05 code, adjacent to but not in M-08's scope.

This PR stays focused on `generate_report`'s return-vs-raise contract per audit issue #74.