### PR TITLE
fix(C6-M-09): validate_detection_replay.py --skip-yara now takes precedence over --require-yara

### DIFF
--- a/scripts/verification/validate_detection_replay.py
+++ b/scripts/verification/validate_detection_replay.py
@@ -266,7 +266,7 @@ def evaluate_yara_case(case: dict[str, Any], yara_command: str | None, require_y
         # FIX: C5-M-01 — returning passed=True here was a false-pass: YARA rules were never evaluated.
         # A skipped-but-unchecked YARA case is not a pass; it is a coverage gap that must surface as
         # a non-pass so callers cannot treat the run as a clean full-coverage result.
-        return ReplayResult(case["name"], "yara", False, "coverage-incomplete: yara command not available (use --skip-yara to opt out explicitly or --require-yara to hard-fail)")  # FIX: C5-M-01
+        return ReplayResult(case["name"], "yara", False, "coverage-incomplete: yara command not available")  # FIX: C5-M-01 FIX: C6-M-09
 
     rule_path = REPO_ROOT / case["rule"]
     fixture_path = REPO_ROOT / case["fixture"]
@@ -303,6 +303,11 @@ def run_validation(cases_path: Path, *, skip_yara: bool, require_yara: bool) -> 
             results.append(evaluate_sigma_case(case))
         elif kind == "yara":
             yara_cases_present = True  # FIX: C5-M-01
+            if skip_yara:  # FIX: C6-M-09 — skip_yara takes precedence; emit explicit-skip result instead of per-case FAIL
+                # Operator opted out via --skip-yara; emit a passed=True explicit-skip result so the  # FIX: C6-M-09
+                # case is traceable (vs. silent continue) and aggregate all(r.passed) stays True per operator intent.  # FIX: C6-M-09
+                results.append(ReplayResult(case["name"], "yara", True, "explicitly-skipped: --skip-yara active"))  # FIX: C6-M-09
+                continue  # FIX: C6-M-09
             results.append(evaluate_yara_case(case, yara_command, require_yara))
         else:
             raise ValueError(f"Unsupported replay case kind: {kind}")


### PR DESCRIPTION
## Summary

Fixes audit finding **C6-M-09** (part of [issue #74 — C6-M-Batch-C](https://github.com/topazyo/openclaw-security-playbook/issues/74)).

`validate_detection_replay.py` previously produced per-case `passed=False` results for every YARA case when `--skip-yara --require-yara` were both passed — silently downgrading the "skip" intent to a stream of FAILs. The fix makes `--skip-yara` precedence explicit: when set, the YARA cases short-circuit before evaluation, regardless of `--require-yara`.

## Fix

Three coordinated changes:

1. **`--skip-yara` precedence** — `run_validation` short-circuits YARA cases when `skip_yara=True`, never invoking `evaluate_yara_case` for those cases.

2. **Explicit-skip emit** — instead of silently consuming the case (silent absence in results), emit `ReplayResult(name, "yara", passed=True, "explicitly-skipped: --skip-yara active")`. Operator gets per-case traceability; aggregate `all(r.passed)` stays `True` per operator intent.

3. **Shortened coverage-incomplete message** — the per-case `coverage-incomplete: yara command not available (use --skip-yara to opt out explicitly or --require-yara to hard-fail)` is shortened to `coverage-incomplete: yara command not available`. The flag guidance is preserved in the top-level `[COVERAGE-INCOMPLETE]` summary at L392 — one canonical location, no duplication.

Every modified line carries `# FIX: C6-M-09` (in addition to preserving existing `# FIX: C5-M-01` tags).

## Test plan

- [x] `--skip-yara` alone → yara cases produce explicit-skip results, sigma cases proceed
- [x] `--skip-yara --require-yara` → no per-case FAILs for yara, exit 0 (per audit criteria)
- [x] No flags (yara installed) → yara cases evaluate normally
- [x] No flags (yara unavailable) → per-case `coverage-incomplete` + top-level sentinel

## Out of scope

Three follow-up findings surfaced during Copilot review of this PR and filed as separate audit issues:

- **#105 (C6-H-10)** — Operator-modifier silent overwrite (`field|contains|gte` etc.). Bundled per-modifier comparison coverage tests into the same issue.
- **#106 (C6-H-11)** — `find_high_risk_yara_patterns` helper exists + tested but never wired into production `evaluate_yara_case`.

This PR stays focused on the `--skip-yara` precedence per audit issue #74.