### PR TITLE
Resolve Pylance diagnostics and enforce LF line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json,md,toml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,38 @@
+# Normalize all text files to LF in the repository and in the working tree.
+# Git's auto-detection chooses text vs binary; `eol=lf` overrides core.autocrlf
+# so Windows checkouts do not introduce CRLF into the working tree.
+* text=auto eol=lf
+
+# Explicit text rules for executable scripts and config formats.
+*.sh        text eol=lf
+*.bash      text eol=lf
+*.py        text eol=lf
+*.yml       text eol=lf
+*.yaml      text eol=lf
+*.json      text eol=lf
+*.md        text eol=lf
+*.toml      text eol=lf
+*.conf      text eol=lf
+*.txt       text eol=lf
+*.kql       text eol=lf
+*.spl       text eol=lf
+*.yar       text eol=lf
+Dockerfile  text eol=lf
+Makefile    text eol=lf
+
+# Explicit binary rules so Git never tries to diff or normalize these.
+*.png       binary
+*.jpg       binary
+*.jpeg      binary
+*.gif       binary
+*.ico       binary
+*.pdf       binary
+*.zip       binary
+*.gz        binary
+*.tar       binary
+*.db        binary
+*.rdb       binary
+
+# Postgres / Prometheus runtime data under scripts/hardening/docker/data is
+# never text; mark the whole tree binary so checkouts do not corrupt it.
+scripts/hardening/docker/data/** binary

--- a/tests/integration/test_backup_recovery.py
+++ b/tests/integration/test_backup_recovery.py
@@ -50,7 +50,7 @@ def _fake_boto3_with_backup_pages(pages, snapshots=None):  # FIX: C5-finding-3
     fake_ec2_client = MagicMock()  # FIX: C5-finding-3
     fake_ec2_client.describe_snapshots.return_value = {"Snapshots": snapshots or []}  # FIX: C5-finding-3
     fake_boto3 = ModuleType("boto3")  # FIX: C5-finding-3
-    fake_boto3.client = Mock(side_effect=lambda service_name, region_name=None: {"s3": fake_s3_client, "ec2": fake_ec2_client}[service_name])  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_boto3.client = Mock(side_effect=lambda service_name, region_name=None: {"s3": fake_s3_client, "ec2": fake_ec2_client}[service_name])  # type: ignore[attr-defined]  # FIX: C5-finding-3
     return fake_boto3, fake_s3_client, fake_paginator, fake_ec2_client  # FIX: C5-finding-3
 
 

--- a/tests/integration/test_backup_recovery.py
+++ b/tests/integration/test_backup_recovery.py
@@ -50,7 +50,7 @@ def _fake_boto3_with_backup_pages(pages, snapshots=None):  # FIX: C5-finding-3
     fake_ec2_client = MagicMock()  # FIX: C5-finding-3
     fake_ec2_client.describe_snapshots.return_value = {"Snapshots": snapshots or []}  # FIX: C5-finding-3
     fake_boto3 = ModuleType("boto3")  # FIX: C5-finding-3
-    fake_boto3.client = Mock(side_effect=lambda service_name, region_name=None: {"s3": fake_s3_client, "ec2": fake_ec2_client}[service_name])  # FIX: C5-finding-3
+    fake_boto3.client = Mock(side_effect=lambda service_name, region_name=None: {"s3": fake_s3_client, "ec2": fake_ec2_client}[service_name])  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
     return fake_boto3, fake_s3_client, fake_paginator, fake_ec2_client  # FIX: C5-finding-3
 
 

--- a/tests/integration/test_modified_function_claims.py
+++ b/tests/integration/test_modified_function_claims.py
@@ -92,12 +92,12 @@ def _load_auto_containment_context(tmp_path, module_name: str):
         module_name,
         {"boto3": fake_boto3, "docker": fake_docker},
     )
-    module.CONTAINMENT_LOG_DIR = tmp_path / module_name
-    module.CONTAINMENT_LOG_DIR.mkdir(parents=True, exist_ok=True)
-    module.BLOCK_NETWORK_ACL_ID = None
-    module.DNS_FIREWALL_DOMAIN_LIST_ID = None
-    module.RATE_LIMIT_CONFIG_PATH = None
-    module.QUARANTINE_SG_ID = "sg-quarantine"
+    module.CONTAINMENT_LOG_DIR = tmp_path / module_name  # type: ignore[attr-defined]  # pylance: dynamic module attr injection
+    module.CONTAINMENT_LOG_DIR.mkdir(parents=True, exist_ok=True)  # type: ignore[attr-defined]  # pylance: dynamic module attr
+    module.BLOCK_NETWORK_ACL_ID = None  # type: ignore[attr-defined]  # pylance: dynamic module attr injection
+    module.DNS_FIREWALL_DOMAIN_LIST_ID = None  # type: ignore[attr-defined]  # pylance: dynamic module attr injection
+    module.RATE_LIMIT_CONFIG_PATH = None  # type: ignore[attr-defined]  # pylance: dynamic module attr injection
+    module.QUARANTINE_SG_ID = "sg-quarantine"  # type: ignore[attr-defined]  # pylance: dynamic module attr injection
 
     return SimpleNamespace(
         module=module,
@@ -113,21 +113,21 @@ def _load_auto_containment_context(tmp_path, module_name: str):
 
 def _load_forensics_collector_module(module_name: str):
     fake_psutil = ModuleType("psutil")
-    fake_psutil.Error = RuntimeError
-    fake_psutil.NoSuchProcess = RuntimeError
-    fake_psutil.AccessDenied = RuntimeError
-    fake_psutil.disk_partitions = MagicMock()
-    fake_psutil.disk_usage = MagicMock()
-    fake_psutil.process_iter = MagicMock()
-    fake_psutil.net_connections = MagicMock()
+    fake_psutil.Error = RuntimeError  # type: ignore[attr-defined]  # pylance: synthetic module stub
+    fake_psutil.NoSuchProcess = RuntimeError  # type: ignore[attr-defined]  # pylance: synthetic module stub
+    fake_psutil.AccessDenied = RuntimeError  # type: ignore[attr-defined]  # pylance: synthetic module stub
+    fake_psutil.disk_partitions = MagicMock()  # type: ignore[attr-defined]  # pylance: synthetic module stub
+    fake_psutil.disk_usage = MagicMock()  # type: ignore[attr-defined]  # pylance: synthetic module stub
+    fake_psutil.process_iter = MagicMock()  # type: ignore[attr-defined]  # pylance: synthetic module stub
+    fake_psutil.net_connections = MagicMock()  # type: ignore[attr-defined]  # pylance: synthetic module stub
     fake_cryptography = ModuleType("cryptography")
     fake_hazmat = ModuleType("cryptography.hazmat")
     fake_primitives = ModuleType("cryptography.hazmat.primitives")
-    fake_primitives.hashes = ModuleType("hashes")
-    fake_primitives.serialization = ModuleType("serialization")
+    fake_primitives.hashes = ModuleType("hashes")  # type: ignore[attr-defined]  # pylance: synthetic module stub
+    fake_primitives.serialization = ModuleType("serialization")  # type: ignore[attr-defined]  # pylance: synthetic module stub
     fake_asymmetric = ModuleType("cryptography.hazmat.primitives.asymmetric")
-    fake_asymmetric.rsa = ModuleType("rsa")
-    fake_asymmetric.padding = ModuleType("padding")
+    fake_asymmetric.rsa = ModuleType("rsa")  # type: ignore[attr-defined]  # pylance: synthetic module stub
+    fake_asymmetric.padding = ModuleType("padding")  # type: ignore[attr-defined]  # pylance: synthetic module stub
     return _load_module_from_path(
         FORENSICS_COLLECTOR_PATH,
         module_name,

--- a/tests/integration/test_modified_function_claims.py
+++ b/tests/integration/test_modified_function_claims.py
@@ -92,12 +92,12 @@ def _load_auto_containment_context(tmp_path, module_name: str):
         module_name,
         {"boto3": fake_boto3, "docker": fake_docker},
     )
-    module.CONTAINMENT_LOG_DIR = tmp_path / module_name  # type: ignore[attr-defined]  # pylance: dynamic module attr injection
-    module.CONTAINMENT_LOG_DIR.mkdir(parents=True, exist_ok=True)  # type: ignore[attr-defined]  # pylance: dynamic module attr
-    module.BLOCK_NETWORK_ACL_ID = None  # type: ignore[attr-defined]  # pylance: dynamic module attr injection
-    module.DNS_FIREWALL_DOMAIN_LIST_ID = None  # type: ignore[attr-defined]  # pylance: dynamic module attr injection
-    module.RATE_LIMIT_CONFIG_PATH = None  # type: ignore[attr-defined]  # pylance: dynamic module attr injection
-    module.QUARANTINE_SG_ID = "sg-quarantine"  # type: ignore[attr-defined]  # pylance: dynamic module attr injection
+    module.CONTAINMENT_LOG_DIR = tmp_path / module_name  # type: ignore[attr-defined]
+    module.CONTAINMENT_LOG_DIR.mkdir(parents=True, exist_ok=True)  # type: ignore[attr-defined]
+    module.BLOCK_NETWORK_ACL_ID = None  # type: ignore[attr-defined]
+    module.DNS_FIREWALL_DOMAIN_LIST_ID = None  # type: ignore[attr-defined]
+    module.RATE_LIMIT_CONFIG_PATH = None  # type: ignore[attr-defined]
+    module.QUARANTINE_SG_ID = "sg-quarantine"  # type: ignore[attr-defined]
 
     return SimpleNamespace(
         module=module,
@@ -113,21 +113,21 @@ def _load_auto_containment_context(tmp_path, module_name: str):
 
 def _load_forensics_collector_module(module_name: str):
     fake_psutil = ModuleType("psutil")
-    fake_psutil.Error = RuntimeError  # type: ignore[attr-defined]  # pylance: synthetic module stub
-    fake_psutil.NoSuchProcess = RuntimeError  # type: ignore[attr-defined]  # pylance: synthetic module stub
-    fake_psutil.AccessDenied = RuntimeError  # type: ignore[attr-defined]  # pylance: synthetic module stub
-    fake_psutil.disk_partitions = MagicMock()  # type: ignore[attr-defined]  # pylance: synthetic module stub
-    fake_psutil.disk_usage = MagicMock()  # type: ignore[attr-defined]  # pylance: synthetic module stub
-    fake_psutil.process_iter = MagicMock()  # type: ignore[attr-defined]  # pylance: synthetic module stub
-    fake_psutil.net_connections = MagicMock()  # type: ignore[attr-defined]  # pylance: synthetic module stub
+    fake_psutil.Error = RuntimeError  # type: ignore[attr-defined]
+    fake_psutil.NoSuchProcess = RuntimeError  # type: ignore[attr-defined]
+    fake_psutil.AccessDenied = RuntimeError  # type: ignore[attr-defined]
+    fake_psutil.disk_partitions = MagicMock()  # type: ignore[attr-defined]
+    fake_psutil.disk_usage = MagicMock()  # type: ignore[attr-defined]
+    fake_psutil.process_iter = MagicMock()  # type: ignore[attr-defined]
+    fake_psutil.net_connections = MagicMock()  # type: ignore[attr-defined]
     fake_cryptography = ModuleType("cryptography")
     fake_hazmat = ModuleType("cryptography.hazmat")
     fake_primitives = ModuleType("cryptography.hazmat.primitives")
-    fake_primitives.hashes = ModuleType("hashes")  # type: ignore[attr-defined]  # pylance: synthetic module stub
-    fake_primitives.serialization = ModuleType("serialization")  # type: ignore[attr-defined]  # pylance: synthetic module stub
+    fake_primitives.hashes = ModuleType("hashes")  # type: ignore[attr-defined]
+    fake_primitives.serialization = ModuleType("serialization")  # type: ignore[attr-defined]
     fake_asymmetric = ModuleType("cryptography.hazmat.primitives.asymmetric")
-    fake_asymmetric.rsa = ModuleType("rsa")  # type: ignore[attr-defined]  # pylance: synthetic module stub
-    fake_asymmetric.padding = ModuleType("padding")  # type: ignore[attr-defined]  # pylance: synthetic module stub
+    fake_asymmetric.rsa = ModuleType("rsa")  # type: ignore[attr-defined]
+    fake_asymmetric.padding = ModuleType("padding")  # type: ignore[attr-defined]
     return _load_module_from_path(
         FORENSICS_COLLECTOR_PATH,
         module_name,

--- a/tests/integration/test_playbook_procedures.py
+++ b/tests/integration/test_playbook_procedures.py
@@ -69,7 +69,7 @@ def _load_auto_containment_module(tmp_path):  # FIX: C5-finding-3
     with patch.dict(sys.modules, {"boto3": fake_boto3, "docker": fake_docker}):  # FIX: C5-finding-3
         sys.modules[spec.name] = module  # FIX: C5-finding-3
         spec.loader.exec_module(module)  # FIX: C5-finding-3
-    module.CONTAINMENT_LOG_DIR = log_dir  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: dynamic module attr injection for testing
+    module.CONTAINMENT_LOG_DIR = log_dir  # type: ignore[attr-defined]  # FIX: C5-finding-3
     return module, log_dir, fake_ec2, fake_route53resolver, fake_docker_client, fake_network, fake_container  # FIX: C5-finding-3
 
 
@@ -86,21 +86,21 @@ def _read_single_report(log_dir):  # FIX: C5-finding-3
 
 def _load_forensics_collector_module(module_name):  # FIX: C5-finding-3
     fake_psutil = ModuleType("psutil")  # FIX: C5-finding-3
-    fake_psutil.Error = RuntimeError  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
-    fake_psutil.NoSuchProcess = RuntimeError  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
-    fake_psutil.AccessDenied = RuntimeError  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
-    fake_psutil.disk_partitions = Mock()  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
-    fake_psutil.disk_usage = Mock()  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
-    fake_psutil.process_iter = Mock()  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
-    fake_psutil.net_connections = Mock()  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_psutil.Error = RuntimeError  # type: ignore[attr-defined]  # FIX: C5-finding-3
+    fake_psutil.NoSuchProcess = RuntimeError  # type: ignore[attr-defined]  # FIX: C5-finding-3
+    fake_psutil.AccessDenied = RuntimeError  # type: ignore[attr-defined]  # FIX: C5-finding-3
+    fake_psutil.disk_partitions = Mock()  # type: ignore[attr-defined]  # FIX: C5-finding-3
+    fake_psutil.disk_usage = Mock()  # type: ignore[attr-defined]  # FIX: C5-finding-3
+    fake_psutil.process_iter = Mock()  # type: ignore[attr-defined]  # FIX: C5-finding-3
+    fake_psutil.net_connections = Mock()  # type: ignore[attr-defined]  # FIX: C5-finding-3
     fake_cryptography = ModuleType("cryptography")  # FIX: C5-finding-3
     fake_hazmat = ModuleType("cryptography.hazmat")  # FIX: C5-finding-3
     fake_primitives = ModuleType("cryptography.hazmat.primitives")  # FIX: C5-finding-3
-    fake_primitives.hashes = ModuleType("hashes")  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
-    fake_primitives.serialization = ModuleType("serialization")  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_primitives.hashes = ModuleType("hashes")  # type: ignore[attr-defined]  # FIX: C5-finding-3
+    fake_primitives.serialization = ModuleType("serialization")  # type: ignore[attr-defined]  # FIX: C5-finding-3
     fake_asymmetric = ModuleType("cryptography.hazmat.primitives.asymmetric")  # FIX: C5-finding-3
-    fake_asymmetric.rsa = ModuleType("rsa")  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
-    fake_asymmetric.padding = ModuleType("padding")  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_asymmetric.rsa = ModuleType("rsa")  # type: ignore[attr-defined]  # FIX: C5-finding-3
+    fake_asymmetric.padding = ModuleType("padding")  # type: ignore[attr-defined]  # FIX: C5-finding-3
     spec = importlib.util.spec_from_file_location(module_name, FORENSICS_COLLECTOR_PATH)  # FIX: C5-finding-3
     assert spec is not None and spec.loader is not None  # FIX: C5-finding-3
     module = importlib.util.module_from_spec(spec)  # FIX: C5-finding-3
@@ -118,8 +118,8 @@ def _load_forensics_collector_module(module_name):  # FIX: C5-finding-3
 
 def _load_ioc_scanner_module(module_name):  # FIX: C5-finding-3
     fake_requests = ModuleType("requests")  # FIX: C5-finding-3
-    fake_requests.get = Mock()  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
-    fake_requests.exceptions = SimpleNamespace(RequestException=Exception)  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_requests.get = Mock()  # type: ignore[attr-defined]  # FIX: C5-finding-3
+    fake_requests.exceptions = SimpleNamespace(RequestException=Exception)  # type: ignore[attr-defined]  # FIX: C5-finding-3
     spec = importlib.util.spec_from_file_location(module_name, IOC_SCANNER_PATH)  # FIX: C5-finding-3
     assert spec is not None and spec.loader is not None  # FIX: C5-finding-3
     module = importlib.util.module_from_spec(spec)  # FIX: C5-finding-3
@@ -161,11 +161,11 @@ def _load_timeline_generator_module(module_name):  # FIX: C5-finding-3
     fake_logs_client = MagicMock()  # FIX: C5-finding-3
     fake_cloudtrail_client = MagicMock()  # FIX: C5-finding-3
     fake_elasticsearch = ModuleType("elasticsearch")  # FIX: C5-finding-3
-    fake_elasticsearch.Elasticsearch = MagicMock(return_value=fake_es_client)  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_elasticsearch.Elasticsearch = MagicMock(return_value=fake_es_client)  # type: ignore[attr-defined]  # FIX: C5-finding-3
     fake_boto3 = ModuleType("boto3")  # FIX: C5-finding-3
-    fake_boto3.client = MagicMock(side_effect=lambda service_name, region_name=None: {"logs": fake_logs_client, "cloudtrail": fake_cloudtrail_client}[service_name])  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_boto3.client = MagicMock(side_effect=lambda service_name, region_name=None: {"logs": fake_logs_client, "cloudtrail": fake_cloudtrail_client}[service_name])  # type: ignore[attr-defined]  # FIX: C5-finding-3
     fake_pandas = ModuleType("pandas")  # FIX: C5-finding-3
-    fake_pandas.DataFrame = MagicMock()  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_pandas.DataFrame = MagicMock()  # type: ignore[attr-defined]  # FIX: C5-finding-3
     spec = importlib.util.spec_from_file_location(module_name, TIMELINE_GENERATOR_PATH)  # FIX: C5-finding-3
     assert spec is not None and spec.loader is not None  # FIX: C5-finding-3
     module = importlib.util.module_from_spec(spec)  # FIX: C5-finding-3
@@ -180,9 +180,9 @@ def _load_impact_analyzer_module(module_name):  # FIX: C5-finding-3
     fake_iam = MagicMock()  # FIX: C5-finding-3
     fake_graph = MagicMock()  # FIX: C5-finding-3
     fake_boto3 = ModuleType("boto3")  # FIX: C5-finding-3
-    fake_boto3.client = MagicMock(side_effect=lambda service_name, region_name=None: {"ec2": fake_ec2, "iam": fake_iam}[service_name])  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_boto3.client = MagicMock(side_effect=lambda service_name, region_name=None: {"ec2": fake_ec2, "iam": fake_iam}[service_name])  # type: ignore[attr-defined]  # FIX: C5-finding-3
     fake_networkx = ModuleType("networkx")  # FIX: C5-finding-3
-    fake_networkx.DiGraph = MagicMock(return_value=fake_graph)  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_networkx.DiGraph = MagicMock(return_value=fake_graph)  # type: ignore[attr-defined]  # FIX: C5-finding-3
     spec = importlib.util.spec_from_file_location(module_name, IMPACT_ANALYZER_PATH)  # FIX: C5-finding-3
     assert spec is not None and spec.loader is not None  # FIX: C5-finding-3
     module = importlib.util.module_from_spec(spec)  # FIX: C5-finding-3
@@ -259,7 +259,7 @@ class TestDetectionPhase:
     def test_ioc_scanner_threat_intel(self, incident_simulator):  # FIX: C5-finding-3
         """Test IOC scanner queries threat intelligence through the real AbuseIPDB path."""  # FIX: C5-finding-3
         module, fake_requests = _load_ioc_scanner_module("ioc_scanner_detection_issue_7_tests")  # FIX: C5-finding-3
-        module.ABUSEIPDB_API_KEY = "abuseipdb-test-key"  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: dynamic module attr injection
+        module.ABUSEIPDB_API_KEY = "abuseipdb-test-key"  # type: ignore[attr-defined]  # FIX: C5-finding-3
         fake_response = Mock()  # FIX: C5-finding-3
         fake_response.raise_for_status.return_value = None  # FIX: C5-finding-3
         fake_response.json.return_value = {  # FIX: C5-finding-3
@@ -432,8 +432,8 @@ class TestForensicsCollectorRuntimeParity:
     def test_notification_manager_sends_pagerduty(self, incident_simulator):  # FIX: C5-finding-3
         """Test notification-manager.py sends PagerDuty alert."""  # FIX: C5-finding-3
         module = _load_notification_manager_module("notification_manager_issue_7_tests")  # FIX: C5-finding-3
-        module.PAGERDUTY_API_KEY = "pagerduty-token"  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: dynamic module attr injection
-        module.PAGERDUTY_SERVICE_ID = "service-12345"  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: dynamic module attr injection
+        module.PAGERDUTY_API_KEY = "pagerduty-token"  # type: ignore[attr-defined]  # FIX: C5-finding-3
+        module.PAGERDUTY_SERVICE_ID = "service-12345"  # type: ignore[attr-defined]  # FIX: C5-finding-3
         manager = module.NotificationManager(incident_simulator["incident_id"], "critical")  # FIX: C5-finding-3
         fake_response = Mock()  # FIX: C5-finding-3
         fake_response.raise_for_status.return_value = None  # FIX: C5-finding-3
@@ -698,8 +698,8 @@ class TestRecoveryPhase:
         fake_conn = MagicMock()  # FIX: C5-finding-3
         fake_conn.cursor.return_value = fake_cursor  # FIX: C5-finding-3
         fake_psycopg2 = ModuleType("psycopg2")  # FIX: C5-finding-3
-        fake_psycopg2.connect = Mock(return_value=fake_conn)  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
-        fake_psycopg2.Error = Exception  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+        fake_psycopg2.connect = Mock(return_value=fake_conn)  # type: ignore[attr-defined]  # FIX: C5-finding-3
+        fake_psycopg2.Error = Exception  # type: ignore[attr-defined]  # FIX: C5-finding-3
 
         with patch.dict(sys.modules, {"psycopg2": fake_psycopg2}):  # FIX: C5-finding-3
             manager._run_smoke_tests("postgresql://restore-target")  # FIX: C5-finding-3

--- a/tests/integration/test_playbook_procedures.py
+++ b/tests/integration/test_playbook_procedures.py
@@ -69,7 +69,7 @@ def _load_auto_containment_module(tmp_path):  # FIX: C5-finding-3
     with patch.dict(sys.modules, {"boto3": fake_boto3, "docker": fake_docker}):  # FIX: C5-finding-3
         sys.modules[spec.name] = module  # FIX: C5-finding-3
         spec.loader.exec_module(module)  # FIX: C5-finding-3
-    module.CONTAINMENT_LOG_DIR = log_dir  # FIX: C5-finding-3
+    module.CONTAINMENT_LOG_DIR = log_dir  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: dynamic module attr injection for testing
     return module, log_dir, fake_ec2, fake_route53resolver, fake_docker_client, fake_network, fake_container  # FIX: C5-finding-3
 
 
@@ -86,21 +86,21 @@ def _read_single_report(log_dir):  # FIX: C5-finding-3
 
 def _load_forensics_collector_module(module_name):  # FIX: C5-finding-3
     fake_psutil = ModuleType("psutil")  # FIX: C5-finding-3
-    fake_psutil.Error = RuntimeError  # FIX: C5-finding-3
-    fake_psutil.NoSuchProcess = RuntimeError  # FIX: C5-finding-3
-    fake_psutil.AccessDenied = RuntimeError  # FIX: C5-finding-3
-    fake_psutil.disk_partitions = Mock()  # FIX: C5-finding-3
-    fake_psutil.disk_usage = Mock()  # FIX: C5-finding-3
-    fake_psutil.process_iter = Mock()  # FIX: C5-finding-3
-    fake_psutil.net_connections = Mock()  # FIX: C5-finding-3
+    fake_psutil.Error = RuntimeError  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_psutil.NoSuchProcess = RuntimeError  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_psutil.AccessDenied = RuntimeError  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_psutil.disk_partitions = Mock()  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_psutil.disk_usage = Mock()  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_psutil.process_iter = Mock()  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_psutil.net_connections = Mock()  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
     fake_cryptography = ModuleType("cryptography")  # FIX: C5-finding-3
     fake_hazmat = ModuleType("cryptography.hazmat")  # FIX: C5-finding-3
     fake_primitives = ModuleType("cryptography.hazmat.primitives")  # FIX: C5-finding-3
-    fake_primitives.hashes = ModuleType("hashes")  # FIX: C5-finding-3
-    fake_primitives.serialization = ModuleType("serialization")  # FIX: C5-finding-3
+    fake_primitives.hashes = ModuleType("hashes")  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_primitives.serialization = ModuleType("serialization")  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
     fake_asymmetric = ModuleType("cryptography.hazmat.primitives.asymmetric")  # FIX: C5-finding-3
-    fake_asymmetric.rsa = ModuleType("rsa")  # FIX: C5-finding-3
-    fake_asymmetric.padding = ModuleType("padding")  # FIX: C5-finding-3
+    fake_asymmetric.rsa = ModuleType("rsa")  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_asymmetric.padding = ModuleType("padding")  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
     spec = importlib.util.spec_from_file_location(module_name, FORENSICS_COLLECTOR_PATH)  # FIX: C5-finding-3
     assert spec is not None and spec.loader is not None  # FIX: C5-finding-3
     module = importlib.util.module_from_spec(spec)  # FIX: C5-finding-3
@@ -118,8 +118,8 @@ def _load_forensics_collector_module(module_name):  # FIX: C5-finding-3
 
 def _load_ioc_scanner_module(module_name):  # FIX: C5-finding-3
     fake_requests = ModuleType("requests")  # FIX: C5-finding-3
-    fake_requests.get = Mock()  # FIX: C5-finding-3
-    fake_requests.exceptions = SimpleNamespace(RequestException=Exception)  # FIX: C5-finding-3
+    fake_requests.get = Mock()  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+    fake_requests.exceptions = SimpleNamespace(RequestException=Exception)  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
     spec = importlib.util.spec_from_file_location(module_name, IOC_SCANNER_PATH)  # FIX: C5-finding-3
     assert spec is not None and spec.loader is not None  # FIX: C5-finding-3
     module = importlib.util.module_from_spec(spec)  # FIX: C5-finding-3
@@ -161,11 +161,11 @@ def _load_timeline_generator_module(module_name):  # FIX: C5-finding-3
     fake_logs_client = MagicMock()  # FIX: C5-finding-3
     fake_cloudtrail_client = MagicMock()  # FIX: C5-finding-3
     fake_elasticsearch = ModuleType("elasticsearch")  # FIX: C5-finding-3
-    fake_elasticsearch.Elasticsearch = MagicMock(return_value=fake_es_client)  # FIX: C5-finding-3
+    fake_elasticsearch.Elasticsearch = MagicMock(return_value=fake_es_client)  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
     fake_boto3 = ModuleType("boto3")  # FIX: C5-finding-3
-    fake_boto3.client = MagicMock(side_effect=lambda service_name, region_name=None: {"logs": fake_logs_client, "cloudtrail": fake_cloudtrail_client}[service_name])  # FIX: C5-finding-3
+    fake_boto3.client = MagicMock(side_effect=lambda service_name, region_name=None: {"logs": fake_logs_client, "cloudtrail": fake_cloudtrail_client}[service_name])  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
     fake_pandas = ModuleType("pandas")  # FIX: C5-finding-3
-    fake_pandas.DataFrame = MagicMock()  # FIX: C5-finding-3
+    fake_pandas.DataFrame = MagicMock()  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
     spec = importlib.util.spec_from_file_location(module_name, TIMELINE_GENERATOR_PATH)  # FIX: C5-finding-3
     assert spec is not None and spec.loader is not None  # FIX: C5-finding-3
     module = importlib.util.module_from_spec(spec)  # FIX: C5-finding-3
@@ -180,9 +180,9 @@ def _load_impact_analyzer_module(module_name):  # FIX: C5-finding-3
     fake_iam = MagicMock()  # FIX: C5-finding-3
     fake_graph = MagicMock()  # FIX: C5-finding-3
     fake_boto3 = ModuleType("boto3")  # FIX: C5-finding-3
-    fake_boto3.client = MagicMock(side_effect=lambda service_name, region_name=None: {"ec2": fake_ec2, "iam": fake_iam}[service_name])  # FIX: C5-finding-3
+    fake_boto3.client = MagicMock(side_effect=lambda service_name, region_name=None: {"ec2": fake_ec2, "iam": fake_iam}[service_name])  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
     fake_networkx = ModuleType("networkx")  # FIX: C5-finding-3
-    fake_networkx.DiGraph = MagicMock(return_value=fake_graph)  # FIX: C5-finding-3
+    fake_networkx.DiGraph = MagicMock(return_value=fake_graph)  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
     spec = importlib.util.spec_from_file_location(module_name, IMPACT_ANALYZER_PATH)  # FIX: C5-finding-3
     assert spec is not None and spec.loader is not None  # FIX: C5-finding-3
     module = importlib.util.module_from_spec(spec)  # FIX: C5-finding-3
@@ -259,7 +259,7 @@ class TestDetectionPhase:
     def test_ioc_scanner_threat_intel(self, incident_simulator):  # FIX: C5-finding-3
         """Test IOC scanner queries threat intelligence through the real AbuseIPDB path."""  # FIX: C5-finding-3
         module, fake_requests = _load_ioc_scanner_module("ioc_scanner_detection_issue_7_tests")  # FIX: C5-finding-3
-        module.ABUSEIPDB_API_KEY = "abuseipdb-test-key"  # FIX: C5-finding-3
+        module.ABUSEIPDB_API_KEY = "abuseipdb-test-key"  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: dynamic module attr injection
         fake_response = Mock()  # FIX: C5-finding-3
         fake_response.raise_for_status.return_value = None  # FIX: C5-finding-3
         fake_response.json.return_value = {  # FIX: C5-finding-3
@@ -432,8 +432,8 @@ class TestForensicsCollectorRuntimeParity:
     def test_notification_manager_sends_pagerduty(self, incident_simulator):  # FIX: C5-finding-3
         """Test notification-manager.py sends PagerDuty alert."""  # FIX: C5-finding-3
         module = _load_notification_manager_module("notification_manager_issue_7_tests")  # FIX: C5-finding-3
-        module.PAGERDUTY_API_KEY = "pagerduty-token"  # FIX: C5-finding-3
-        module.PAGERDUTY_SERVICE_ID = "service-12345"  # FIX: C5-finding-3
+        module.PAGERDUTY_API_KEY = "pagerduty-token"  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: dynamic module attr injection
+        module.PAGERDUTY_SERVICE_ID = "service-12345"  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: dynamic module attr injection
         manager = module.NotificationManager(incident_simulator["incident_id"], "critical")  # FIX: C5-finding-3
         fake_response = Mock()  # FIX: C5-finding-3
         fake_response.raise_for_status.return_value = None  # FIX: C5-finding-3
@@ -698,8 +698,8 @@ class TestRecoveryPhase:
         fake_conn = MagicMock()  # FIX: C5-finding-3
         fake_conn.cursor.return_value = fake_cursor  # FIX: C5-finding-3
         fake_psycopg2 = ModuleType("psycopg2")  # FIX: C5-finding-3
-        fake_psycopg2.connect = Mock(return_value=fake_conn)  # FIX: C5-finding-3
-        fake_psycopg2.Error = Exception  # FIX: C5-finding-3
+        fake_psycopg2.connect = Mock(return_value=fake_conn)  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
+        fake_psycopg2.Error = Exception  # type: ignore[attr-defined]  # FIX: C5-finding-3  # pylance: synthetic module stub
 
         with patch.dict(sys.modules, {"psycopg2": fake_psycopg2}):  # FIX: C5-finding-3
             manager._run_smoke_tests("postgresql://restore-target")  # FIX: C5-finding-3

--- a/tests/security/test_evidence_snapshot_cli.py
+++ b/tests/security/test_evidence_snapshot_cli.py
@@ -13,10 +13,10 @@ from click.testing import CliRunner
 
 MODULE_PATH = Path(__file__).resolve().parents[2] / "tools" / "openclaw-cli.py"
 SPEC = importlib.util.spec_from_file_location("openclaw_cli", MODULE_PATH)
-assert SPEC is not None and SPEC.loader is not None  # pylance: narrow ModuleSpec|None before use
-openclaw_cli = importlib.util.module_from_spec(SPEC)  # pylance: SPEC narrowed above
-sys.modules[SPEC.name] = openclaw_cli  # pylance: SPEC narrowed above
-SPEC.loader.exec_module(openclaw_cli)  # pylance: loader narrowed above
+assert SPEC is not None and SPEC.loader is not None
+openclaw_cli = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = openclaw_cli
+SPEC.loader.exec_module(openclaw_cli)
 
 
 class _Result:

--- a/tests/security/test_evidence_snapshot_cli.py
+++ b/tests/security/test_evidence_snapshot_cli.py
@@ -13,10 +13,10 @@ from click.testing import CliRunner
 
 MODULE_PATH = Path(__file__).resolve().parents[2] / "tools" / "openclaw-cli.py"
 SPEC = importlib.util.spec_from_file_location("openclaw_cli", MODULE_PATH)
-openclaw_cli = importlib.util.module_from_spec(SPEC)
-assert SPEC.loader is not None
-sys.modules[SPEC.name] = openclaw_cli
-SPEC.loader.exec_module(openclaw_cli)
+assert SPEC is not None and SPEC.loader is not None  # pylance: narrow ModuleSpec|None before use
+openclaw_cli = importlib.util.module_from_spec(SPEC)  # pylance: SPEC narrowed above
+sys.modules[SPEC.name] = openclaw_cli  # pylance: SPEC narrowed above
+SPEC.loader.exec_module(openclaw_cli)  # pylance: loader narrowed above
 
 
 class _Result:

--- a/tests/security/test_runtime_security_regression.py
+++ b/tests/security/test_runtime_security_regression.py
@@ -10,10 +10,10 @@ import sys
 
 MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "verification" / "runtime_security_regression.py"
 SPEC = importlib.util.spec_from_file_location("runtime_security_regression", MODULE_PATH)
-runtime_security_regression = importlib.util.module_from_spec(SPEC)
-assert SPEC.loader is not None
-sys.modules[SPEC.name] = runtime_security_regression
-SPEC.loader.exec_module(runtime_security_regression)
+assert SPEC is not None and SPEC.loader is not None  # pylance: narrow ModuleSpec|None before use
+runtime_security_regression = importlib.util.module_from_spec(SPEC)  # pylance: SPEC narrowed above
+sys.modules[SPEC.name] = runtime_security_regression  # pylance: SPEC narrowed above
+SPEC.loader.exec_module(runtime_security_regression)  # pylance: loader narrowed above
 
 
 def test_scenario_selection_all_returns_both_paths() -> None:

--- a/tests/security/test_runtime_security_regression.py
+++ b/tests/security/test_runtime_security_regression.py
@@ -10,10 +10,10 @@ import sys
 
 MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "verification" / "runtime_security_regression.py"
 SPEC = importlib.util.spec_from_file_location("runtime_security_regression", MODULE_PATH)
-assert SPEC is not None and SPEC.loader is not None  # pylance: narrow ModuleSpec|None before use
-runtime_security_regression = importlib.util.module_from_spec(SPEC)  # pylance: SPEC narrowed above
-sys.modules[SPEC.name] = runtime_security_regression  # pylance: SPEC narrowed above
-SPEC.loader.exec_module(runtime_security_regression)  # pylance: loader narrowed above
+assert SPEC is not None and SPEC.loader is not None
+runtime_security_regression = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = runtime_security_regression
+SPEC.loader.exec_module(runtime_security_regression)
 
 
 def test_scenario_selection_all_returns_both_paths() -> None:

--- a/tests/unit/test_collect_evidence_function_claims.py
+++ b/tests/unit/test_collect_evidence_function_claims.py
@@ -13,7 +13,7 @@ _FUNCTION_BLOCK = _SCRIPT_PATH.read_bytes().replace(b"\r", b"").split(b"TIMESTAM
 
 
 def _run_function_block(commands: bytes) -> subprocess.CompletedProcess[bytes]:
-    assert _BASH_PATH is not None, "bash required; tests are skipped without it"  # pylance: narrow Optional[str] from shutil.which
+    assert _BASH_PATH is not None, "bash required; tests are skipped without it"
     return subprocess.run(
         [_BASH_PATH, "-s"],
         capture_output=True,

--- a/tests/unit/test_collect_evidence_function_claims.py
+++ b/tests/unit/test_collect_evidence_function_claims.py
@@ -13,6 +13,7 @@ _FUNCTION_BLOCK = _SCRIPT_PATH.read_bytes().replace(b"\r", b"").split(b"TIMESTAM
 
 
 def _run_function_block(commands: bytes) -> subprocess.CompletedProcess[bytes]:
+    assert _BASH_PATH is not None, "bash required; tests are skipped without it"  # pylance: narrow Optional[str] from shutil.which
     return subprocess.run(
         [_BASH_PATH, "-s"],
         capture_output=True,

--- a/tests/unit/test_collect_evidence_function_claims.py
+++ b/tests/unit/test_collect_evidence_function_claims.py
@@ -13,7 +13,8 @@ _FUNCTION_BLOCK = _SCRIPT_PATH.read_bytes().replace(b"\r", b"").split(b"TIMESTAM
 
 
 def _run_function_block(commands: bytes) -> subprocess.CompletedProcess[bytes]:
-    assert _BASH_PATH is not None, "bash required; tests are skipped without it"
+    if _BASH_PATH is None:
+        pytest.skip("bash is required to execute collect_evidence.sh helpers")
     return subprocess.run(
         [_BASH_PATH, "-s"],
         capture_output=True,

--- a/tests/unit/test_collect_evidence_script.py
+++ b/tests/unit/test_collect_evidence_script.py
@@ -22,7 +22,8 @@ def test_collect_evidence_surfaces_capture_command_failures(tmp_path):
 
     script_input = b"ss() { return 3; }\n" + _SCRIPT_PATH.read_bytes().replace(b"\r", b"")
 
-    assert _BASH_PATH is not None, "bash required; tests are skipped without it"
+    if _BASH_PATH is None:
+        pytest.skip("bash is required to execute collect_evidence.sh")
     result = subprocess.run(
         [_BASH_PATH, "-s"],
         capture_output=True,

--- a/tests/unit/test_collect_evidence_script.py
+++ b/tests/unit/test_collect_evidence_script.py
@@ -22,6 +22,7 @@ def test_collect_evidence_surfaces_capture_command_failures(tmp_path):
 
     script_input = b"ss() { return 3; }\n" + _SCRIPT_PATH.read_bytes().replace(b"\r", b"")
 
+    assert _BASH_PATH is not None, "bash required; tests are skipped without it"  # pylance: narrow Optional[str] from shutil.which
     result = subprocess.run(
         [_BASH_PATH, "-s"],
         capture_output=True,

--- a/tests/unit/test_collect_evidence_script.py
+++ b/tests/unit/test_collect_evidence_script.py
@@ -22,7 +22,7 @@ def test_collect_evidence_surfaces_capture_command_failures(tmp_path):
 
     script_input = b"ss() { return 3; }\n" + _SCRIPT_PATH.read_bytes().replace(b"\r", b"")
 
-    assert _BASH_PATH is not None, "bash required; tests are skipped without it"  # pylance: narrow Optional[str] from shutil.which
+    assert _BASH_PATH is not None, "bash required; tests are skipped without it"
     result = subprocess.run(
         [_BASH_PATH, "-s"],
         capture_output=True,

--- a/tests/unit/test_encryption.py
+++ b/tests/unit/test_encryption.py
@@ -78,7 +78,7 @@ def test_vault_key_manager_creates_keys_and_rotates_versions(encryption_module):
     fake_client.secrets = SimpleNamespace(transit=Mock())  # FIX: C5-finding-4
     fake_client.secrets.transit.read_key.return_value = {"data": {"latest_version": 3}}  # FIX: C5-finding-4
     fake_hvac = ModuleType("hvac")  # FIX: C5-finding-4
-    fake_hvac.Client = Mock(return_value=fake_client)  # type: ignore[attr-defined]  # FIX: C5-finding-4  # pylance: synthetic module stub
+    fake_hvac.Client = Mock(return_value=fake_client)  # type: ignore[attr-defined]  # FIX: C5-finding-4
     with patch.dict(sys.modules, {"hvac": fake_hvac}):  # FIX: C5-finding-4
         manager = encryption_module.VaultKeyManager("http://vault.local", "token")  # FIX: C5-finding-4
         key_name = manager.create_key("openclaw-conversations")  # FIX: C5-finding-4
@@ -96,7 +96,7 @@ def test_vault_key_manager_encrypts_and_decrypts_via_transit(encryption_module):
     fake_client.secrets.transit.encrypt_data.return_value = {"data": {"ciphertext": "vault:v1:encrypted"}}  # FIX: C5-finding-4
     fake_client.secrets.transit.decrypt_data.return_value = {"data": {"plaintext": base64.b64encode(b"secret").decode("utf-8")}}  # FIX: C5-finding-4
     fake_hvac = ModuleType("hvac")  # FIX: C5-finding-4
-    fake_hvac.Client = Mock(return_value=fake_client)  # type: ignore[attr-defined]  # FIX: C5-finding-4  # pylance: synthetic module stub
+    fake_hvac.Client = Mock(return_value=fake_client)  # type: ignore[attr-defined]  # FIX: C5-finding-4
     with patch.dict(sys.modules, {"hvac": fake_hvac}):  # FIX: C5-finding-4
         manager = encryption_module.VaultKeyManager("http://vault.local", "token")  # FIX: C5-finding-4
         ciphertext = manager.encrypt_with_vault("openclaw-conversations", b"secret")  # FIX: C5-finding-4

--- a/tests/unit/test_encryption.py
+++ b/tests/unit/test_encryption.py
@@ -78,7 +78,7 @@ def test_vault_key_manager_creates_keys_and_rotates_versions(encryption_module):
     fake_client.secrets = SimpleNamespace(transit=Mock())  # FIX: C5-finding-4
     fake_client.secrets.transit.read_key.return_value = {"data": {"latest_version": 3}}  # FIX: C5-finding-4
     fake_hvac = ModuleType("hvac")  # FIX: C5-finding-4
-    fake_hvac.Client = Mock(return_value=fake_client)  # FIX: C5-finding-4
+    fake_hvac.Client = Mock(return_value=fake_client)  # type: ignore[attr-defined]  # FIX: C5-finding-4  # pylance: synthetic module stub
     with patch.dict(sys.modules, {"hvac": fake_hvac}):  # FIX: C5-finding-4
         manager = encryption_module.VaultKeyManager("http://vault.local", "token")  # FIX: C5-finding-4
         key_name = manager.create_key("openclaw-conversations")  # FIX: C5-finding-4
@@ -96,7 +96,7 @@ def test_vault_key_manager_encrypts_and_decrypts_via_transit(encryption_module):
     fake_client.secrets.transit.encrypt_data.return_value = {"data": {"ciphertext": "vault:v1:encrypted"}}  # FIX: C5-finding-4
     fake_client.secrets.transit.decrypt_data.return_value = {"data": {"plaintext": base64.b64encode(b"secret").decode("utf-8")}}  # FIX: C5-finding-4
     fake_hvac = ModuleType("hvac")  # FIX: C5-finding-4
-    fake_hvac.Client = Mock(return_value=fake_client)  # FIX: C5-finding-4
+    fake_hvac.Client = Mock(return_value=fake_client)  # type: ignore[attr-defined]  # FIX: C5-finding-4  # pylance: synthetic module stub
     with patch.dict(sys.modules, {"hvac": fake_hvac}):  # FIX: C5-finding-4
         manager = encryption_module.VaultKeyManager("http://vault.local", "token")  # FIX: C5-finding-4
         ciphertext = manager.encrypt_with_vault("openclaw-conversations", b"secret")  # FIX: C5-finding-4


### PR DESCRIPTION
Address Pylance diagnostics across the test suite by removing tool-specific comments and ensuring consistent line endings with `.gitattributes` and `.editorconfig`. Update tests to handle missing bash more gracefully and maintain compatibility with existing markers.