### PR TITLE
chore(typing): resolve pylance diagnostics in auto-containment.py

### DIFF
--- a/scripts/incident-response/auto-containment.py
+++ b/scripts/incident-response/auto-containment.py
@@ -48,7 +48,7 @@ except ImportError:
     boto3 = None  # FIX: C5-finding-3
 
 try:
-    import docker  # FIX: C5-finding-3
+    import docker  # pyright: ignore[reportMissingModuleSource]  # pylance: docker source absent in CI/dev envs; runtime import guarded by except below
 except ImportError:
     docker = None  # FIX: C5-finding-3
 
@@ -658,7 +658,8 @@ class ContainmentManager:
             "actions_taken": self.actions_taken,
             "rollback_commands": self.rollback_commands
         }
-        
+
+        report_file: Optional[Path] = None  # pylance: ensure bound on all paths for rollback summary below
         if self.log_dir is None:
             logger.error("No writable log directory; skipping containment report file")
         else:
@@ -681,7 +682,10 @@ class ContainmentManager:
         
         if self.rollback_commands:
             print(f"\nRollback commands available: {len(self.rollback_commands)}")
-            print(f"See: {report_file}")
+            if report_file is not None:  # pylance: only reference when bound
+                print(f"See: {report_file}")
+            else:
+                print("Report file not written (no writable log directory).")
         print("=" * 80)
 
 


### PR DESCRIPTION
- report_file: initialize as Optional[Path] = None so it is bound on both branches of save_containment_report's log_dir guard; guard the rollback-summary print so the "See: ..." line only appears when the report was actually written. Replaces a latent NameError on the previously-unbound branch with an honest "Report file not written (no writable log directory)." message.
- docker import: add # pyright: ignore[reportMissingModuleSource] for the optional dependency; the runtime ImportError guard is unchanged.

Resolves: 1 Pyright error + 1 Pyright warning (no ruff changes).