### PR TITLE
fix(C6-M-14): skill_integrity_monitor.sh restore_skill now validates original_path is absolute and lacks .. segments before mv

### DIFF
--- a/configs/skill-policies/README.md
+++ b/configs/skill-policies/README.md
@@ -115,39 +115,55 @@ ajv validate -s enforcement-policy-schema.json -d enforcement-policy.json
 
 ### 4. enforcement-policy.json
 
-**Purpose:** Configure enforcement actions and monitoring
+**Purpose:** Configure the one enforcement lever that the monitoring script actually reads — PGP signature verification.
 
-**Settings (consumed by skill_integrity_monitor.sh):**
+> **Honesty note (C6-M-11):** Earlier revisions of this file declared a large
+> surface of enforcement levers (manifest/integrity validation, source
+> validation, pattern-scanning toggles, quarantine triggers, logging config,
+> per-skill exceptions). None of those were ever read by any code path —
+> editing them produced no behaviour change. They have been **removed** from
+> both `enforcement-policy.json` and `enforcement-policy-schema.json` rather
+> than left as config-theater. The table below states exactly what is and is
+> not enforced.
 
-- **Validation rules** - manifest, integrity, signatures (`validation.signature.*` read via jq)
-- **Source validation** - allowlist, HTTPS, certificate checks
-- **Pattern scanning** - enable/disable flags and ignore patterns (severity actions removed — not consumed)
-- **Quarantine rules** - auto-quarantine flag and quarantine triggers
-- **Logging** - log level, rotation settings
-- **Exceptions** - per-skill override list
+**Per-field status:**
 
-**Removed fields (were not consumed by any code):**
+| Top-level group | Status | Enforced by |
+|-----------------|--------|-------------|
+| `version`, `last_updated`, `description` | CONSUMED (metadata) | parsed by every jq read; required by schema |
+| `validation.signature.required` | **CONSUMED** | `scripts/supply-chain/skill_integrity_monitor.sh:406` (`verify_signature`) |
+| `validation.signature.verify_pgp` | **CONSUMED** | `scripts/supply-chain/skill_integrity_monitor.sh:407` (`verify_signature`) |
+| `validation.signature.trusted_keys` | **CONSUMED** | `scripts/supply-chain/skill_integrity_monitor.sh:440` (`verify_signature` key allowlist) |
+| `validation.manifest.*` | REMOVED | never read; manifest validation is hardcoded in `validate_manifest` |
+| `validation.integrity.*` | REMOVED | never read; integrity check is hardcoded |
+| `validation.signature.fail_on_invalid` | REMOVED | never read; an invalid signature always fails `verify_signature` |
+| `source_validation.*` | REMOVED | never read |
+| `pattern_scanning.*` | REMOVED | never read; scanning is governed by presence of `dangerous-patterns.json` and the `$SKILL_SCAN_INTERVAL` / `$AUTO_QUARANTINE` env vars |
+| `quarantine.auto_quarantine` | REMOVED | the policy field was never read; auto-quarantine is driven by the `AUTO_QUARANTINE` env var (`skill_integrity_monitor.sh:787`) |
+| `quarantine.quarantine_on.*` | REMOVED | never read |
+| `quarantine.retention_days` | REMOVED | never read; quarantine pruning uses the `QUARANTINE_RETENTION_DAYS` env var (`skill_integrity_monitor.sh:976`) |
+| `quarantine.notify_on_quarantine` | REMOVED | never read; no notification dispatcher exists |
+| `logging.*` | REMOVED | never read; logging is hardcoded and rotation uses `LOG_RETENTION_DAYS` / `MAX_LOG_SIZE` env vars |
+| `exceptions.skills[]` | REMOVED | never read; no skip-check logic exists |
 
-- `enforcement_level` — no code reads this via jq
-- `pattern_scanning.severity_actions` — severity routing is hardcoded in script logic
-- `permissions` — dangerous_permissions and permission_combinations not read
-- `monitoring` — continuous_monitoring not read; scan interval comes from `$SKILL_SCAN_INTERVAL` env var
-- `notifications` — no notification dispatcher reads this block
-- `compliance` — sbom_required and license_compliance not read
+ADVISORY: there are currently **no** advisory-only fields — a field is either
+consumed by code or it has been removed. Quarantine/log retention, scan
+interval, and auto-quarantine behaviour are configured via **environment
+variables**, not this file (see Environment Variables below).
 
-**Example (consumed fields only):**
+**Example (this is the entire consumed surface):**
 
 ```json
 {
+  "version": "1.0.0",
+  "last_updated": "2026-05-30T12:00:00Z",
+  "description": "Skill security enforcement policy",
   "validation": {
     "signature": {
       "required": true,
       "verify_pgp": true,
       "trusted_keys": []
     }
-  },
-  "quarantine": {
-    "auto_quarantine": true
   }
 }
 ```
@@ -225,7 +241,11 @@ Edit `dangerous-patterns.json`:
 
 ### Adjusting Enforcement
 
-Edit `enforcement-policy.json` (only fields below are consumed by code):
+Edit `enforcement-policy.json`. The **only** fields consumed by code are the
+signature-verification settings below — there are no other enforcement levers in
+this file (see the per-field status table above). To adjust quarantine
+retention, auto-quarantine, or scan interval, use the environment variables
+listed under Environment Variables instead.
 
 ```json
 {
@@ -234,16 +254,6 @@ Edit `enforcement-policy.json` (only fields below are consumed by code):
       "required": true,
       "verify_pgp": true,
       "trusted_keys": []
-    }
-  },
-  "quarantine": {
-    "auto_quarantine": true,
-    "quarantine_on": {
-      "integrity_failure": true,
-      "dangerous_patterns": {
-        "critical": true,
-        "high": true
-      }
     }
   }
 }
@@ -291,52 +301,64 @@ Edit `enforcement-policy.json` (only fields below are consumed by code):
 
 ### Enforcement Semantics Contract (POLICY-SEM-001)
 
-The following semantics are treated as contract-level defaults for production:
+> **Updated for C6-M-11.** The previous version of this contract described
+> semantics (enforcement-level routing, source-validation blocking, integrity
+> gating, severity→action mapping, dangerous-permission mapping) that were
+> **never read from `enforcement-policy.json`** — they were config-theater.
+> This contract now lists only what the policy file actually controls; the
+> remaining behaviours below are hardcoded in `skill_integrity_monitor.sh` and
+> are not policy-configurable.
 
-- `production` enforcement level is `block`.
-- Untrusted sources are blocked (`source_validation.block_untrusted: true`).
-- Signature and integrity validation are mandatory (`validation.signature.required: true`, `validation.integrity.required: true`).
-- Unsigned skills are rejected (`validation.integrity.allow_unsigned: false`).
-- Invalid signatures fail validation (`validation.signature.fail_on_invalid: true`).
-- Pattern scanning actions are stable:
-  - `critical` → `block` + quarantine
-  - `high` → `block` + quarantine
-  - `medium` → `warn`
-  - `low` → `log`
-- Dangerous permissions are policy-mapped and deterministic:
-  - `process:exec` → `block`
-  - `network:unrestricted` → `block`
-  - `filesystem:write` → `warn`
-  - `secrets:write` → `block`
+Policy-file-controlled (read from `enforcement-policy.json`):
 
-Do not relax these defaults without a documented contract decision and cross-file audit update.
+- Signature verification is mandatory by default (`validation.signature.required: true`).
+- PGP signature verification is enabled by default (`validation.signature.verify_pgp: true`).
+- When `validation.signature.trusted_keys` is non-empty, only those keys are accepted (`skill_integrity_monitor.sh:440`).
+
+Hardcoded in the script (NOT policy-configurable — do not expect these to react to JSON edits):
+
+- An invalid or unverifiable signature always fails `verify_signature` (there is no `fail_on_invalid` toggle).
+- Manifest schema validation and SHA-256 integrity checking are always performed by their respective functions.
+- Pattern scanning runs whenever `dangerous-patterns.json` is present; there is no enable/disable toggle in this file.
+- Auto-quarantine on failure is driven by the `AUTO_QUARANTINE` environment variable, not by `quarantine.auto_quarantine`.
+
+Do not relax the policy-controlled defaults without a documented contract decision and cross-file audit update.
 
 ---
 
 ## Best Practices
 
-### 1. Keep Production Enforcement Immutable
+### 1. Keep Signature Verification Mandatory
 
-```json
-"enforcement_level": {
-  "production": "block"
-}
-```
-
-### 2. Use Exceptions Sparingly
+The only enforcement lever in `enforcement-policy.json` is signature
+verification. Keep it locked down:
 
 ```json
 {
-  "exceptions": {
-    "skills": [
-      {
-        "id": "legacy-skill",
-        "reason": "Legacy system integration",
-        "expiry": "2026-12-31", // Set expiration
-        "skip_checks": ["pattern_scanning"],
-        "approved_by": "security-team" // Track approval
-      }
-    ]
+  "validation": {
+    "signature": {
+      "required": true,
+      "verify_pgp": true
+    }
+  }
+}
+```
+
+> There is no `enforcement_level` field and no per-skill `exceptions` block —
+> those were removed in C6-M-11 because no code read them. Do not re-add them
+> expecting a behaviour change.
+
+### 2. Pin Trusted Signing Keys
+
+Populate `validation.signature.trusted_keys` to restrict accepted signers
+(empty = any otherwise-valid signature is accepted):
+
+```json
+{
+  "validation": {
+    "signature": {
+      "trusted_keys": ["<pgp-key-id-or-fingerprint>"]
+    }
   }
 }
 ```
@@ -452,16 +474,13 @@ eval(trusted_input)
 ### High Resource Usage
 
 ```bash
-# Reduce scan frequency
+# Reduce scan frequency (scan interval is an env var, not a policy field)
 export SKILL_SCAN_INTERVAL="600"  # 10 minutes
-
-# Disable expensive checks in dev
-{
-  "pattern_scanning": {
-    "scan_dependencies": false
-  }
-}
 ```
+
+> Note: there is no `pattern_scanning` block in `enforcement-policy.json` to
+> disable individual checks — those toggles were removed in C6-M-11 because no
+> code read them. Tune scan frequency with `SKILL_SCAN_INTERVAL` instead.
 
 ---
 

--- a/configs/skill-policies/README.md
+++ b/configs/skill-policies/README.md
@@ -131,17 +131,17 @@ ajv validate -s enforcement-policy-schema.json -d enforcement-policy.json
 | Top-level group | Status | Enforced by |
 |-----------------|--------|-------------|
 | `version`, `last_updated`, `description` | CONSUMED (metadata) | parsed by every jq read; required by schema |
-| `validation.signature.required` | **CONSUMED** | `scripts/supply-chain/skill_integrity_monitor.sh:406` (`verify_signature`) |
-| `validation.signature.verify_pgp` | **CONSUMED** | `scripts/supply-chain/skill_integrity_monitor.sh:407` (`verify_signature`) |
-| `validation.signature.trusted_keys` | **CONSUMED** | `scripts/supply-chain/skill_integrity_monitor.sh:440` (`verify_signature` key allowlist) |
+| `validation.signature.required` | **CONSUMED** | `verify_signature()` in `scripts/supply-chain/skill_integrity_monitor.sh` |
+| `validation.signature.verify_pgp` | **CONSUMED** | `verify_signature()` in `scripts/supply-chain/skill_integrity_monitor.sh` |
+| `validation.signature.trusted_keys` | **CONSUMED** | `verify_signature()` in `scripts/supply-chain/skill_integrity_monitor.sh` (trusted-keys allowlist) |
 | `validation.manifest.*` | REMOVED | never read; manifest validation is hardcoded in `validate_manifest` |
 | `validation.integrity.*` | REMOVED | never read; integrity check is hardcoded |
 | `validation.signature.fail_on_invalid` | REMOVED | never read; an invalid signature always fails `verify_signature` |
 | `source_validation.*` | REMOVED | never read |
 | `pattern_scanning.*` | REMOVED | never read; scanning is governed by presence of `dangerous-patterns.json` and the `$SKILL_SCAN_INTERVAL` / `$AUTO_QUARANTINE` env vars |
-| `quarantine.auto_quarantine` | REMOVED | the policy field was never read; auto-quarantine is driven by the `AUTO_QUARANTINE` env var (`skill_integrity_monitor.sh:787`) |
+| `quarantine.auto_quarantine` | REMOVED | the policy field was never read; auto-quarantine is driven by the `AUTO_QUARANTINE` env var (read in `scan_all_skills()`) |
 | `quarantine.quarantine_on.*` | REMOVED | never read |
-| `quarantine.retention_days` | REMOVED | never read; quarantine pruning uses the `QUARANTINE_RETENTION_DAYS` env var (`skill_integrity_monitor.sh:976`) |
+| `quarantine.retention_days` | REMOVED | never read; quarantine pruning uses the `QUARANTINE_RETENTION_DAYS` env var (read in `clean_quarantine()`) |
 | `quarantine.notify_on_quarantine` | REMOVED | never read; no notification dispatcher exists |
 | `logging.*` | REMOVED | never read; logging is hardcoded and rotation uses `LOG_RETENTION_DAYS` / `MAX_LOG_SIZE` env vars |
 | `exceptions.skills[]` | REMOVED | never read; no skip-check logic exists |
@@ -313,7 +313,7 @@ Policy-file-controlled (read from `enforcement-policy.json`):
 
 - Signature verification is mandatory by default (`validation.signature.required: true`).
 - PGP signature verification is enabled by default (`validation.signature.verify_pgp: true`).
-- When `validation.signature.trusted_keys` is non-empty, only those keys are accepted (`skill_integrity_monitor.sh:440`).
+- When `validation.signature.trusted_keys` is non-empty, only those keys are accepted (enforced in `verify_signature()`).
 
 Hardcoded in the script (NOT policy-configurable — do not expect these to react to JSON edits):
 

--- a/configs/skill-policies/enforcement-policy-schema.json
+++ b/configs/skill-policies/enforcement-policy-schema.json
@@ -2,17 +2,13 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://openclaw.ai/schemas/skill-enforcement-policy-v1.json",
   "title": "OpenClaw Skill Enforcement Policy",
+  "description": "Schema for the post-C6-M-11 minimal enforcement policy. Only fields actually consumed by skill_integrity_monitor.sh are permitted; unconsumed config-theater fields were removed.",
   "type": "object",
   "required": [
     "version",
     "last_updated",
     "description",
-    "validation",
-    "source_validation",
-    "pattern_scanning",
-    "quarantine",
-    "logging",
-    "exceptions"
+    "validation"
   ],
   "additionalProperties": false,
   "properties": {
@@ -24,199 +20,24 @@
     "description": { "type": "string", "minLength": 1 },
     "validation": {
       "type": "object",
-      "required": ["manifest", "integrity", "signature"],
+      "required": ["signature"],
       "additionalProperties": false,
       "properties": {
-        "manifest": {
-          "type": "object",
-          "required": [
-            "required",
-            "schema_validation",
-            "fail_on_missing",
-            "fail_on_invalid"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "required": { "type": "boolean" },
-            "schema_validation": { "type": "boolean" },
-            "fail_on_missing": { "type": "boolean" },
-            "fail_on_invalid": { "type": "boolean" }
-          }
-        },
-        "integrity": {
-          "type": "object",
-          "required": [
-            "required",
-            "algorithm",
-            "fail_on_mismatch",
-            "allow_unsigned"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "required": { "type": "boolean" },
-            "algorithm": { "type": "string", "minLength": 1 },
-            "fail_on_mismatch": { "type": "boolean" },
-            "allow_unsigned": { "type": "boolean" }
-          }
-        },
         "signature": {
           "type": "object",
           "required": [
             "required",
             "verify_pgp",
-            "trusted_keys",
-            "fail_on_invalid"
+            "trusted_keys"
           ],
           "additionalProperties": false,
           "properties": {
             "required": { "type": "boolean" },
             "verify_pgp": { "type": "boolean" },
-            "trusted_keys": { "type": "array", "items": { "type": "string" } },
-            "fail_on_invalid": { "type": "boolean" }
+            "trusted_keys": { "type": "array", "items": { "type": "string" } }
           }
         }
       }
-    },
-    "source_validation": {
-      "type": "object",
-      "required": [
-        "check_allowlist",
-        "block_untrusted",
-        "warn_untrusted",
-        "require_https",
-        "check_certificate"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "check_allowlist": { "type": "boolean" },
-        "block_untrusted": { "type": "boolean" },
-        "warn_untrusted": { "type": "boolean" },
-        "require_https": { "type": "boolean" },
-        "check_certificate": { "type": "boolean" }
-      }
-    },
-    "pattern_scanning": {
-      "type": "object",
-      "required": [
-        "enabled",
-        "scan_code",
-        "scan_config",
-        "scan_dependencies",
-        "ignore_patterns"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "enabled": { "type": "boolean" },
-        "scan_code": { "type": "boolean" },
-        "scan_config": { "type": "boolean" },
-        "scan_dependencies": { "type": "boolean" },
-        "ignore_patterns": { "type": "array", "items": { "type": "string" } }
-      }
-    },
-    "quarantine": {
-      "type": "object",
-      "required": [
-        "auto_quarantine",
-        "quarantine_on",
-        "retention_days",
-        "notify_on_quarantine"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "auto_quarantine": { "type": "boolean" },
-        "quarantine_on": {
-          "type": "object",
-          "required": [
-            "integrity_failure",
-            "signature_invalid",
-            "dangerous_patterns",
-            "blocked_source",
-            "blocked_author"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "integrity_failure": { "type": "boolean" },
-            "signature_invalid": { "type": "boolean" },
-            "dangerous_patterns": {
-              "type": "object",
-              "required": ["critical", "high"],
-              "additionalProperties": false,
-              "properties": {
-                "critical": { "type": "boolean" },
-                "high": { "type": "boolean" }
-              }
-            },
-            "blocked_source": { "type": "boolean" },
-            "blocked_author": { "type": "boolean" }
-          }
-        },
-        "retention_days": { "type": "integer", "minimum": 1 },
-        "notify_on_quarantine": { "type": "boolean" }
-      }
-    },
-    "logging": {
-      "type": "object",
-      "required": [
-        "log_level",
-        "log_validation",
-        "log_scans",
-        "log_quarantine",
-        "audit_all_actions",
-        "rotation"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "log_level": {
-          "type": "string",
-          "enum": ["debug", "info", "warn", "error"]
-        },
-        "log_validation": { "type": "boolean" },
-        "log_scans": { "type": "boolean" },
-        "log_quarantine": { "type": "boolean" },
-        "audit_all_actions": { "type": "boolean" },
-        "rotation": {
-          "type": "object",
-          "required": ["max_size_mb", "retention_days"],
-          "additionalProperties": false,
-          "properties": {
-            "max_size_mb": { "type": "integer", "minimum": 1 },
-            "retention_days": { "type": "integer", "minimum": 1 }
-          }
-        }
-      }
-    },
-    "exceptions": {
-      "type": "object",
-      "required": ["skills"],
-      "additionalProperties": false,
-      "properties": {
-        "skills": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["id", "reason", "expiry", "skip_checks"],
-            "additionalProperties": true,
-            "properties": {
-              "id": { "type": "string", "minLength": 1 },
-              "reason": { "type": "string", "minLength": 1 },
-              "expiry": {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              "skip_checks": {
-                "type": "array",
-                "items": { "type": "string", "minLength": 1 }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  "definitions": {
-    "action": {
-      "type": "string",
-      "enum": ["block", "warn", "log"]
     }
   }
 }

--- a/configs/skill-policies/enforcement-policy.json
+++ b/configs/skill-policies/enforcement-policy.json
@@ -1,86 +1,13 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-02-14T12:00:00Z",
-  "description": "Skill security enforcement policy",
+  "last_updated": "2026-05-30T12:00:00Z",
+  "description": "Skill security enforcement policy. Only fields below are consumed by skill_integrity_monitor.sh; previously-theatrical, unconsumed fields were removed (see README.md changelog, C6-M-11).",
 
   "validation": {
-    "manifest": {
-      "required": true,
-      "schema_validation": true,
-      "fail_on_missing": true,
-      "fail_on_invalid": true
-    },
-
-    "integrity": {
-      "required": true,
-      "algorithm": "sha256",
-      "fail_on_mismatch": true,
-      "allow_unsigned": false
-    },
-
     "signature": {
       "required": true,
       "verify_pgp": true,
-      "trusted_keys": [],
-      "fail_on_invalid": true
+      "trusted_keys": []
     }
-  },
-
-  "source_validation": {
-    "check_allowlist": true,
-    "block_untrusted": true,
-    "warn_untrusted": false,
-    "require_https": true,
-    "check_certificate": true
-  },
-
-  "pattern_scanning": {
-    "enabled": true,
-    "scan_code": true,
-    "scan_config": true,
-    "scan_dependencies": false,
-
-    "ignore_patterns": ["# nosec", "# security: ignore"]
-  },
-
-  "quarantine": {
-    "auto_quarantine": true,
-    "quarantine_on": {
-      "integrity_failure": true,
-      "signature_invalid": true,
-      "dangerous_patterns": {
-        "critical": true,
-        "high": true
-      },
-      "blocked_source": true,
-      "blocked_author": true
-    },
-
-    "retention_days": 90,
-    "notify_on_quarantine": true
-  },
-
-  "logging": {
-    "log_level": "info",
-    "log_validation": true,
-    "log_scans": true,
-    "log_quarantine": true,
-    "audit_all_actions": true,
-
-    "rotation": {
-      "max_size_mb": 100,
-      "retention_days": 30
-    }
-  },
-
-  "exceptions": {
-    "skills": [
-      {
-        "id": "legacy-skill",
-        "reason": "Grandfather clause for existing deployment",
-        "expiry": "2026-12-31",
-        "skip_checks": ["pattern_scanning"]
-      }
-    ]
   }
 }

--- a/scripts/supply-chain/skill_integrity_monitor.sh
+++ b/scripts/supply-chain/skill_integrity_monitor.sh
@@ -749,6 +749,21 @@ restore_skill() {
         return 1
     fi
 
+    # Defense-in-depth: the metadata file lives on disk and could be tampered with ## FIX: C6-M-14
+    # after quarantine, so validate the restore target's shape before mv. Note we do ## FIX: C6-M-14
+    # NOT require it to live under SKILLS_DIR — legitimate quarantine sources (and the ## FIX: C6-M-14
+    # C6-M-06 fixture) live elsewhere (e.g. /tmp/...). ## FIX: C6-M-14
+    if [[ "$original_path" != /* ]]; then ## FIX: C6-M-14
+        error "Refusing restore: original_path must be absolute (got: $original_path)" ## FIX: C6-M-14
+        audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=not_absolute | path=$original_path" ## FIX: C6-M-14
+        return 1 ## FIX: C6-M-14
+    fi ## FIX: C6-M-14
+    if [[ "$original_path" == *..* ]]; then ## FIX: C6-M-14
+        error "Refusing restore: original_path must not contain '..' (got: $original_path)" ## FIX: C6-M-14
+        audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=traversal | path=$original_path" ## FIX: C6-M-14
+        return 1 ## FIX: C6-M-14
+    fi ## FIX: C6-M-14
+
     # Restore skill
     if mv "$quarantine_path" "$original_path"; then
         success "Skill restored: $original_path"

--- a/scripts/supply-chain/skill_integrity_monitor.sh
+++ b/scripts/supply-chain/skill_integrity_monitor.sh
@@ -548,23 +548,39 @@ _warn_malformed_patterns() { ## FIX: C6-M-15
     fi ## FIX: C6-M-15
 } ## FIX: C6-M-15
 
+# A totally-unusable dangerous-patterns policy (absent, unreadable, or unparseable) ## FIX: C6-M-15
+# means the scan CANNOT run. Fail CLOSED by default (return 1 -> caller counts an issue, ## FIX: C6-M-15
+# CI sees the skill as non-clean) so a control that never ran is never mistaken for a ## FIX: C6-M-15
+# clean result. Operators who must scan without the policy can opt into fail-open ## FIX: C6-M-15
+# explicitly and auditably via ALLOW_MISSING_PATTERN_POLICY=1. ## FIX: C6-M-15
+# Args: $1 = audit tag, $2 = human-readable detail. Returns 0 (fail-open) or 1 (fail-closed). ## FIX: C6-M-15
+_pattern_policy_unavailable() { ## FIX: C6-M-15
+    local audit_tag=$1 ## FIX: C6-M-15
+    local detail=$2 ## FIX: C6-M-15
+    if [ "${ALLOW_MISSING_PATTERN_POLICY:-0}" = "1" ]; then ## FIX: C6-M-15
+        warning "${detail} (pattern scanning skipped; fail-open via ALLOW_MISSING_PATTERN_POLICY=1)" ## FIX: C6-M-15
+        audit "$audit_tag" "File: $PATTERNS_FILE | fail_open=1" ## FIX: C6-M-15
+        return 0 ## FIX: C6-M-15
+    fi ## FIX: C6-M-15
+    error "${detail} (pattern scanning FAILED; set ALLOW_MISSING_PATTERN_POLICY=1 to fail open)" ## FIX: C6-M-15
+    audit "$audit_tag" "File: $PATTERNS_FILE | fail_open=0" ## FIX: C6-M-15
+    return 1 ## FIX: C6-M-15
+} ## FIX: C6-M-15
+
 scan_dangerous_patterns() {
     local skill_dir=$1
 
+    # Distinguish a wholly-unusable policy (absent / unparseable — control cannot run) ## FIX: C6-M-15
+    # from a merely-malformed entry (partial degradation, handled per-section below). ## FIX: C6-M-15
+    # The unusable case fails closed by default; see _pattern_policy_unavailable. ## FIX: C6-M-15
     if [ ! -f "$PATTERNS_FILE" ]; then ## FIX: C6-M-15
-        # Distinguish "no policy" (error) from "malformed policy" (warn) so operators ## FIX: C6-M-15
-        # can tell whether detection coverage is silently absent vs. partially degraded. ## FIX: C6-M-15
-        error "Dangerous-patterns policy file not found: $PATTERNS_FILE (pattern scanning skipped)" ## FIX: C6-M-15
-        audit "PATTERN_POLICY_MISSING" "File: $PATTERNS_FILE" ## FIX: C6-M-15
-        return 0 ## FIX: C6-M-15
+        _pattern_policy_unavailable "PATTERN_POLICY_MISSING" "Dangerous-patterns policy file not found: $PATTERNS_FILE" ## FIX: C6-M-15
+        return $? ## FIX: C6-M-15
     fi
 
-    # An unreadable or syntactically-invalid policy file is a distinct error from ## FIX: C6-M-15
-    # a merely-malformed entry: nothing can be parsed, so emit error (not warn). ## FIX: C6-M-15
     if ! jq empty "$PATTERNS_FILE" >/dev/null 2>&1; then ## FIX: C6-M-15
-        error "Dangerous-patterns policy file is unreadable or not valid JSON: $PATTERNS_FILE (pattern scanning skipped)" ## FIX: C6-M-15
-        audit "PATTERN_POLICY_INVALID" "File: $PATTERNS_FILE" ## FIX: C6-M-15
-        return 0 ## FIX: C6-M-15
+        _pattern_policy_unavailable "PATTERN_POLICY_INVALID" "Dangerous-patterns policy file is unreadable or not valid JSON: $PATTERNS_FILE" ## FIX: C6-M-15
+        return $? ## FIX: C6-M-15
     fi
 
     info "Scanning for dangerous patterns..."
@@ -1097,6 +1113,9 @@ ENVIRONMENT VARIABLES:
     LOG_RETENTION_DAYS           Log retention period (default: 30)
     QUARANTINE_RETENTION_DAYS    Quarantine retention (default: 90)
     AUTO_QUARANTINE              Auto-quarantine on failure (true/false)
+    ALLOW_MISSING_PATTERN_POLICY Fail OPEN when the dangerous-patterns policy is absent or
+                                 unparseable (1 = log warning, skip scan, return success;
+                                 default 0 = fail closed: log error, count an issue)
 
 For more information, see: docs/guides/06-supply-chain-security.md
 

--- a/scripts/supply-chain/skill_integrity_monitor.sh
+++ b/scripts/supply-chain/skill_integrity_monitor.sh
@@ -521,18 +521,58 @@ verify_signature() {
     return 0
 }
 
+# Emit an operator-visible warning when entries in a dangerous-patterns section ## FIX: C6-M-15
+# are malformed (missing the `pattern` field) or the section is present but is not ## FIX: C6-M-15
+# an array. Detection still proceeds with the valid entries (fail-open by design for ## FIX: C6-M-15
+# backward compatibility), but the operator is no longer left blind to the silent skip. ## FIX: C6-M-15
+# Args: $1 = jq section key (e.g. .patterns, .file_patterns, .network_patterns) ## FIX: C6-M-15
+_warn_malformed_patterns() { ## FIX: C6-M-15
+    local section=$1 ## FIX: C6-M-15
+    local malformed ## FIX: C6-M-15
+    # Count: a present-but-non-array section yields 1 (the whole section is unusable); ## FIX: C6-M-15
+    # an array yields the number of elements that lack a non-null string `pattern`. ## FIX: C6-M-15
+    # A wholly-absent section yields 0 (nothing declared is not a malformation). ## FIX: C6-M-15
+    malformed=$(jq -r --arg sec "${section#.}" ' ## FIX: C6-M-15
+        (.[$sec]) as $s ## FIX: C6-M-15
+        | if ($s == null) then 0 ## FIX: C6-M-15
+          elif (($s | type) != "array") then 1 ## FIX: C6-M-15
+          else ([ $s[] | select((.pattern | type) != "string") ] | length) ## FIX: C6-M-15
+          end ## FIX: C6-M-15
+    ' "$PATTERNS_FILE" 2>/dev/null || echo "0") ## FIX: C6-M-15
+    if ! [[ "$malformed" =~ ^[0-9]+$ ]]; then ## FIX: C6-M-15
+        malformed=0 ## FIX: C6-M-15
+    fi ## FIX: C6-M-15
+    if [ "$malformed" -gt 0 ]; then ## FIX: C6-M-15
+        warning "Malformed dangerous-pattern entries skipped in ${section} (${PATTERNS_FILE}): ${malformed} entr(y/ies) missing a 'pattern' field or section is not an array" ## FIX: C6-M-15
+        audit "PATTERN_MALFORMED" "File: $PATTERNS_FILE | Section: $section | Count: $malformed" ## FIX: C6-M-15
+    fi ## FIX: C6-M-15
+} ## FIX: C6-M-15
+
 scan_dangerous_patterns() {
     local skill_dir=$1
 
-    if [ ! -f "$PATTERNS_FILE" ]; then
-        return 0
+    if [ ! -f "$PATTERNS_FILE" ]; then ## FIX: C6-M-15
+        # Distinguish "no policy" (error) from "malformed policy" (warn) so operators ## FIX: C6-M-15
+        # can tell whether detection coverage is silently absent vs. partially degraded. ## FIX: C6-M-15
+        error "Dangerous-patterns policy file not found: $PATTERNS_FILE (pattern scanning skipped)" ## FIX: C6-M-15
+        audit "PATTERN_POLICY_MISSING" "File: $PATTERNS_FILE" ## FIX: C6-M-15
+        return 0 ## FIX: C6-M-15
+    fi
+
+    # An unreadable or syntactically-invalid policy file is a distinct error from ## FIX: C6-M-15
+    # a merely-malformed entry: nothing can be parsed, so emit error (not warn). ## FIX: C6-M-15
+    if ! jq empty "$PATTERNS_FILE" >/dev/null 2>&1; then ## FIX: C6-M-15
+        error "Dangerous-patterns policy file is unreadable or not valid JSON: $PATTERNS_FILE (pattern scanning skipped)" ## FIX: C6-M-15
+        audit "PATTERN_POLICY_INVALID" "File: $PATTERNS_FILE" ## FIX: C6-M-15
+        return 0 ## FIX: C6-M-15
     fi
 
     info "Scanning for dangerous patterns..."
 
     local patterns
     local exceptions
-    patterns=$(jq -r '.patterns[].pattern // empty' "$PATTERNS_FILE" 2>/dev/null || echo "")
+    _warn_malformed_patterns ".patterns" ## FIX: C6-M-15
+    patterns=$(jq -r '.patterns[]?.pattern // empty' "$PATTERNS_FILE" 2>/dev/null || echo "") ## FIX: C6-M-15
     exceptions=$(jq -r '.exceptions[]? // empty' "$PATTERNS_FILE" 2>/dev/null || echo "")
     local found_issues=0
 
@@ -568,6 +608,7 @@ scan_dangerous_patterns() {
 
     # Scan file_patterns against file basenames in the skill directory. ## FIX: C5-M-11
     local file_patterns ## FIX: C5-M-11
+    _warn_malformed_patterns ".file_patterns" ## FIX: C6-M-15
     file_patterns=$(jq -r '.file_patterns[]?.pattern // empty' "$PATTERNS_FILE" 2>/dev/null || echo "") ## FIX: C5-M-11
     while IFS= read -r fpattern; do ## FIX: C5-M-11
         if [ -n "$fpattern" ]; then ## FIX: C5-M-11
@@ -589,6 +630,7 @@ scan_dangerous_patterns() {
 
     # Scan network_patterns against file content (URL/IP literals in skill payload). ## FIX: C5-M-11
     local network_patterns ## FIX: C5-M-11
+    _warn_malformed_patterns ".network_patterns" ## FIX: C6-M-15
     network_patterns=$(jq -r '.network_patterns[]?.pattern // empty' "$PATTERNS_FILE" 2>/dev/null || echo "") ## FIX: C5-M-11
     while IFS= read -r npattern; do ## FIX: C5-M-11
         if [ -n "$npattern" ]; then ## FIX: C5-M-11

--- a/scripts/supply-chain/skill_integrity_monitor.sh
+++ b/scripts/supply-chain/skill_integrity_monitor.sh
@@ -758,8 +758,11 @@ restore_skill() {
         audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=not_absolute | path=$original_path" ## FIX: C6-M-14
         return 1 ## FIX: C6-M-14
     fi ## FIX: C6-M-14
-    if [[ "$original_path" == *..* ]]; then ## FIX: C6-M-14
-        error "Refusing restore: original_path must not contain '..' (got: $original_path)" ## FIX: C6-M-14
+    # Reject '..' only as a path component (/.., ../x, x/../y) — not as a substring of a ## FIX: C6-M-14
+    # legitimate filename like /tmp/a..b (Copilot review: precise segment match over breadth). ## FIX: C6-M-14
+    local _traversal_re='(^|/)\.\.(/|$)' ## FIX: C6-M-14
+    if [[ "$original_path" =~ $_traversal_re ]]; then ## FIX: C6-M-14
+        error "Refusing restore: original_path must not contain '..' path segments (got: $original_path)" ## FIX: C6-M-14
         audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=traversal | path=$original_path" ## FIX: C6-M-14
         return 1 ## FIX: C6-M-14
     fi ## FIX: C6-M-14

--- a/scripts/supply-chain/skill_integrity_monitor.sh
+++ b/scripts/supply-chain/skill_integrity_monitor.sh
@@ -543,7 +543,8 @@ _warn_malformed_patterns() { ## FIX: C6-M-15
         malformed=0 ## FIX: C6-M-15
     fi ## FIX: C6-M-15
     if [ "$malformed" -gt 0 ]; then ## FIX: C6-M-15
-        warning "Malformed dangerous-pattern entries skipped in ${section} (${PATTERNS_FILE}): ${malformed} entr(y/ies) missing a 'pattern' field or section is not an array" ## FIX: C6-M-15
+        local noun="entries"; [ "$malformed" -eq 1 ] && noun="entry" ## FIX: C6-M-15
+        warning "Skipped ${malformed} malformed ${noun} in ${section} of ${PATTERNS_FILE} (missing a 'pattern' field, or the section is not an array)" ## FIX: C6-M-15
         audit "PATTERN_MALFORMED" "File: $PATTERNS_FILE | Section: $section | Count: $malformed" ## FIX: C6-M-15
     fi ## FIX: C6-M-15
 } ## FIX: C6-M-15

--- a/scripts/verification/verify_openclaw_security.sh
+++ b/scripts/verification/verify_openclaw_security.sh
@@ -74,7 +74,26 @@ Exit codes:
     0  All checks passed
     1  One or more critical issues found
     2  Warnings found (no critical issues) or invalid arguments
+
+Environment variables:
+    OPENCLAW_VERIFIER_TLS_HOST            (default: 127.0.0.1)
+        Host used for the TLS certificate/version check (Check 3).
+        Override when the MCP server is reachable at a different address.
+
+    OPENCLAW_VERIFIER_TLS_PORT            (default: 8443)
+        Port used for the TLS certificate/version check (Check 3).
+        Override when the MCP server listens on a non-default port.
+
+    OPENCLAW_VERIFIER_SKIP_ENFORCER_PROCESS  (default: 0; set to 1 to bypass)
+        SECURITY NOTE: When set to 1, Check 4 (runtime-enforcer process
+        detection) is bypassed entirely. Check 4 will report SUCCESS
+        (CONFIGURED_PROCESS_CHECK_SKIPPED) without verifying that the
+        openclaw-shield enforcer is actually running. Use ONLY in CI/test
+        environments where the enforcer is confirmed running by other means.
+        Setting this variable in production masks a real security control gap.
+        Used by hosted-CI workflows.
 EOF
+## FIX: C6-M-16
 }
 
 if [ "$#" -gt 0 ]; then


### PR DESCRIPTION
The restore_skill function has been enhanced to validate the original_path extracted from QUARANTINE_INFO.txt. It now checks that the path is absolute and does not contain any '..' segments, providing distinct error messages for each validation failure. This change addresses potential security risks associated with malformed metadata files. Additionally, the enforcement-policy.json has been streamlined to remove unconsumed fields, and the documentation has been updated to reflect these changes.



Fixes #99