### PR TITLE
fix(C6-M-17): enhance restore_skill with origin ledger and validation checks

### DIFF
--- a/scripts/supply-chain/skill_integrity_monitor.sh
+++ b/scripts/supply-chain/skill_integrity_monitor.sh
@@ -1360,4 +1360,8 @@ main() {
     esac
 }
 
-main "$@"
+# Execute main only when run directly; sourcing (tests/tools) defines the functions without ## FIX: C6-M-17
+# executing. Robust to reformatting, unlike an external grep/sed suppression in the harness. ## FIX: C6-M-17
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then ## FIX: C6-M-17
+    main "$@" ## FIX: C6-M-17
+fi ## FIX: C6-M-17

--- a/scripts/supply-chain/skill_integrity_monitor.sh
+++ b/scripts/supply-chain/skill_integrity_monitor.sh
@@ -76,6 +76,11 @@ STATE_DIR="${HOME}/.openclaw/state"
 
 # Files
 PIDFILE="${STATE_DIR}/skill_monitor.pid"
+# Authoritative restore-origin ledger — kept OUTSIDE the (tamperable) quarantine dir so a ## FIX: C6-M-17
+# rewritten QUARANTINE_INFO.txt cannot redirect a restore. One file per quarantine id. ## FIX: C6-M-17
+# NOTE: still under $HOME, so this is defense-in-depth against the documented vector ## FIX: C6-M-17
+# (in-quarantine-dir tampering), not a boundary against full operator-account compromise. ## FIX: C6-M-17
+QUARANTINE_ORIGINS_DIR="${STATE_DIR}/quarantine-origins" ## FIX: C6-M-17
 LOG_FILE="${LOG_DIR}/skill_monitor.log"
 AUDIT_LOG="${LOG_DIR}/skill_audit.log"
 REPORT_FILE="${LOG_DIR}/skill_report_$(date +%Y%m%d_%H%M%S).json"
@@ -170,11 +175,11 @@ initialize() {
 
     # Create directories
     mkdir -p "$CONFIG_DIR" "$SKILLS_DIR" "$QUARANTINE_DIR" \
-             "$LOG_DIR" "$POLICY_DIR" "$STATE_DIR"
+             "$LOG_DIR" "$POLICY_DIR" "$STATE_DIR" "$QUARANTINE_ORIGINS_DIR" ## FIX: C6-M-17
 
     # Check for required commands
     local missing_cmds=()
-    for cmd in jq sha256sum curl; do
+    for cmd in jq sha256sum curl realpath; do ## FIX: C6-M-17 (realpath needed for restore origin canonicalization)
         if ! command -v "$cmd" &> /dev/null; then
             missing_cmds+=("$cmd")
         fi
@@ -719,6 +724,12 @@ quarantine_skill() {
     timestamp=$(date +%Y%m%d_%H%M%S)
     local quarantine_path="${QUARANTINE_DIR}/${skill_name}_${timestamp}"
 
+    # Capture the canonical origin BEFORE moving (the path still exists now). restore_skill ## FIX: C6-M-17
+    # treats the separately-recorded value as authoritative, so a tampered QUARANTINE_INFO.txt ## FIX: C6-M-17
+    # cannot redirect the restore target. ## FIX: C6-M-17
+    local canonical_origin ## FIX: C6-M-17
+    canonical_origin=$(realpath -- "$skill_path" 2>/dev/null || true) ## FIX: C6-M-17
+
     # Move skill to quarantine
     if mv "$skill_path" "$quarantine_path"; then
         success "Skill quarantined: $quarantine_path"
@@ -736,6 +747,14 @@ Quarantine ID: ${skill_name}_${timestamp}
 To restore:
   $SCRIPT_NAME --restore ${skill_name}_${timestamp}
 EOF
+
+        # Record the authoritative origin separately (one file per quarantine id). ## FIX: C6-M-17
+        if [ -n "$canonical_origin" ]; then ## FIX: C6-M-17
+            mkdir -p "$QUARANTINE_ORIGINS_DIR" ## FIX: C6-M-17
+            printf '%s\n' "$canonical_origin" > "${QUARANTINE_ORIGINS_DIR}/${skill_name}_${timestamp}" ## FIX: C6-M-17
+        else ## FIX: C6-M-17
+            warning "Could not resolve canonical origin for $skill_path; restore will require ALLOW_UNTRACKED_RESTORE=1" ## FIX: C6-M-17
+        fi ## FIX: C6-M-17
 
         ((STATS_QUARANTINED++))
         return 0
@@ -757,37 +776,89 @@ restore_skill() {
 
     info "Restoring skill: $quarantine_id"
 
-    # Read original path — awk extracts everything after the 3rd field so paths with spaces round-trip ## FIX: C6-M-06
-    local original_path
-    original_path=$(awk '/^Original Path:/ { $1=$2=""; sub(/^[[:space:]]+/, ""); print }' "${quarantine_path}/QUARANTINE_INFO.txt") ## FIX: C6-M-06
+    # Read the path recorded in the (tamperable) QUARANTINE_INFO.txt — used below for the ## FIX: C6-M-06
+    # tamper cross-check and for the untracked fallback. awk keeps everything after the 3rd ## FIX: C6-M-06
+    # field so paths with spaces round-trip. ## FIX: C6-M-06
+    local info_path ## FIX: C6-M-06
+    info_path=$(awk '/^Original Path:/ { $1=$2=""; sub(/^[[:space:]]+/, ""); print }' "${quarantine_path}/QUARANTINE_INFO.txt") ## FIX: C6-M-06
 
-    if [ -z "$original_path" ]; then
-        error "Could not determine original path"
-        return 1
-    fi
+    # Authoritative origin: recorded at quarantine time OUTSIDE the quarantine dir, so editing ## FIX: C6-M-17
+    # QUARANTINE_INFO.txt alone cannot redirect the restore. This is the source of truth. ## FIX: C6-M-17
+    local origin_record="${QUARANTINE_ORIGINS_DIR}/${quarantine_id}" ## FIX: C6-M-17
+    local target="" ## FIX: C6-M-17
 
-    # Defense-in-depth: the metadata file lives on disk and could be tampered with ## FIX: C6-M-14
-    # after quarantine, so validate the restore target's shape before mv. Note we do ## FIX: C6-M-14
-    # NOT require it to live under SKILLS_DIR — legitimate quarantine sources (and the ## FIX: C6-M-14
-    # C6-M-06 fixture) live elsewhere (e.g. /tmp/...). ## FIX: C6-M-14
-    if [[ "$original_path" != /* ]]; then ## FIX: C6-M-14
-        error "Refusing restore: original_path must be absolute (got: $original_path)" ## FIX: C6-M-14
-        audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=not_absolute | path=$original_path" ## FIX: C6-M-14
+    if [ -f "$origin_record" ]; then ## FIX: C6-M-17
+        # TRACKED restore: trust the recorded origin, not QUARANTINE_INFO.txt. ## FIX: C6-M-17
+        local authoritative ## FIX: C6-M-17
+        authoritative=$(head -n1 "$origin_record") ## FIX: C6-M-17
+        if [ -z "$authoritative" ]; then ## FIX: C6-M-17
+            error "Refusing restore: origin record is empty for $quarantine_id" ## FIX: C6-M-17
+            audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=empty_origin_record" ## FIX: C6-M-17
+            return 1 ## FIX: C6-M-17
+        fi ## FIX: C6-M-17
+        # Tamper detection: QUARANTINE_INFO.txt must agree with the recorded origin. Compare ## FIX: C6-M-17
+        # canonically (-m: the original location no longer exists once the skill was moved). ## FIX: C6-M-17
+        if [ -n "$info_path" ]; then ## FIX: C6-M-17
+            local canon_info ## FIX: C6-M-17
+            canon_info=$(realpath -m -- "$info_path" 2>/dev/null || echo "$info_path") ## FIX: C6-M-17
+            if [ "$canon_info" != "$authoritative" ]; then ## FIX: C6-M-17
+                error "Refusing restore: QUARANTINE_INFO.txt path ($info_path) disagrees with recorded origin ($authoritative) — possible tampering" ## FIX: C6-M-17
+                audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=tamper | info=$info_path | recorded=$authoritative" ## FIX: C6-M-17
+                return 1 ## FIX: C6-M-17
+            fi ## FIX: C6-M-17
+        fi ## FIX: C6-M-17
+        target=$authoritative ## FIX: C6-M-17
+    else ## FIX: C6-M-17
+        # UNTRACKED restore (pre-existing quarantine or lost ledger): fail CLOSED unless the ## FIX: C6-M-17
+        # operator explicitly opts into the weaker QUARANTINE_INFO-only path. ## FIX: C6-M-17
+        if [ "${ALLOW_UNTRACKED_RESTORE:-0}" != "1" ]; then ## FIX: C6-M-17
+            error "Refusing restore: no origin record for $quarantine_id (set ALLOW_UNTRACKED_RESTORE=1 to restore from QUARANTINE_INFO.txt with shape checks only)" ## FIX: C6-M-17
+            audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=untracked" ## FIX: C6-M-17
+            return 1 ## FIX: C6-M-17
+        fi ## FIX: C6-M-17
+        warning "Restoring untracked quarantine $quarantine_id from QUARANTINE_INFO.txt (fail-open via ALLOW_UNTRACKED_RESTORE=1)" ## FIX: C6-M-17
+        target=$info_path ## FIX: C6-M-17
+    fi ## FIX: C6-M-17
+
+    if [ -z "$target" ]; then ## FIX: C6-M-14
+        error "Could not determine original path" ## FIX: C6-M-14
         return 1 ## FIX: C6-M-14
     fi ## FIX: C6-M-14
-    # Reject '..' only as a path component (/.., ../x, x/../y) — not as a substring of a ## FIX: C6-M-14
-    # legitimate filename like /tmp/a..b (Copilot review: precise segment match over breadth). ## FIX: C6-M-14
+
+    # First-line shape guard (C6-M-14), applied to whichever path we resolved. ## FIX: C6-M-14
+    if [[ "$target" != /* ]]; then ## FIX: C6-M-14
+        error "Refusing restore: original_path must be absolute (got: $target)" ## FIX: C6-M-14
+        audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=not_absolute | path=$target" ## FIX: C6-M-14
+        return 1 ## FIX: C6-M-14
+    fi ## FIX: C6-M-14
     local _traversal_re='(^|/)\.\.(/|$)' ## FIX: C6-M-14
-    if [[ "$original_path" =~ $_traversal_re ]]; then ## FIX: C6-M-14
-        error "Refusing restore: original_path must not contain '..' path segments (got: $original_path)" ## FIX: C6-M-14
-        audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=traversal | path=$original_path" ## FIX: C6-M-14
+    if [[ "$target" =~ $_traversal_re ]]; then ## FIX: C6-M-14
+        error "Refusing restore: original_path must not contain '..' path segments (got: $target)" ## FIX: C6-M-14
+        audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=traversal | path=$target" ## FIX: C6-M-14
         return 1 ## FIX: C6-M-14
     fi ## FIX: C6-M-14
+
+    # Symlink-safety: the parent must exist and resolve to itself — i.e. no symlink was ## FIX: C6-M-17
+    # swapped in between quarantine and restore to redirect the mv outside the recorded root. ## FIX: C6-M-17
+    local target_parent real_parent ## FIX: C6-M-17
+    target_parent=$(dirname -- "$target") ## FIX: C6-M-17
+    real_parent=$(realpath -- "$target_parent" 2>/dev/null || true) ## FIX: C6-M-17
+    if [ -z "$real_parent" ]; then ## FIX: C6-M-17
+        error "Refusing restore: target parent directory does not exist: $target_parent" ## FIX: C6-M-17
+        audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=parent_missing | path=$target" ## FIX: C6-M-17
+        return 1 ## FIX: C6-M-17
+    fi ## FIX: C6-M-17
+    if [ "$real_parent" != "$target_parent" ]; then ## FIX: C6-M-17
+        error "Refusing restore: target parent resolves elsewhere (symlink?): $target_parent -> $real_parent" ## FIX: C6-M-17
+        audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=parent_symlink | path=$target | resolved=$real_parent" ## FIX: C6-M-17
+        return 1 ## FIX: C6-M-17
+    fi ## FIX: C6-M-17
 
     # Restore skill
-    if mv "$quarantine_path" "$original_path"; then
-        success "Skill restored: $original_path"
-        audit "RESTORE" "Skill: $quarantine_id | Restored to: $original_path"
+    if mv "$quarantine_path" "$target"; then
+        success "Skill restored: $target"
+        audit "RESTORE" "Skill: $quarantine_id | Restored to: $target"
+        rm -f "$origin_record" ## FIX: C6-M-17 (consume the origin record once restored)
         return 0
     else
         error "Failed to restore skill"
@@ -1117,6 +1188,9 @@ ENVIRONMENT VARIABLES:
     ALLOW_MISSING_PATTERN_POLICY Fail OPEN when the dangerous-patterns policy is absent or
                                  unparseable (1 = log warning, skip scan, return success;
                                  default 0 = fail closed: log error, count an issue)
+    ALLOW_UNTRACKED_RESTORE      Allow --restore of a quarantine with no recorded origin
+                                 (pre-existing/lost ledger): 1 = restore from QUARANTINE_INFO.txt
+                                 with shape checks only; default 0 = fail closed (refuse)
 
 For more information, see: docs/guides/06-supply-chain-security.md
 

--- a/scripts/supply-chain/skill_integrity_monitor.sh
+++ b/scripts/supply-chain/skill_integrity_monitor.sh
@@ -788,6 +788,17 @@ EOF
 restore_skill() {
     local quarantine_id=$1
 
+    # Validate the id is a single safe path component before using it to build paths that are ## FIX: C6-M-17
+    # later read AND rm-ed, so a crafted --restore id cannot traverse out of QUARANTINE_DIR / ## FIX: C6-M-17
+    # QUARANTINE_ORIGINS_DIR. Spaces stay allowed (ids embed the skill basename, which may have ## FIX: C6-M-17
+    # them); '/', the '.'/'..' components, and control characters are rejected. ## FIX: C6-M-17
+    if [ -z "$quarantine_id" ] || [ "$quarantine_id" = "." ] || [ "$quarantine_id" = ".." ] \
+       || [[ "$quarantine_id" == */* ]] || [[ "$quarantine_id" == *[[:cntrl:]]* ]]; then ## FIX: C6-M-17
+        error "Refusing restore: invalid quarantine id (must be a single path component): '$quarantine_id'" ## FIX: C6-M-17
+        audit "RESTORE_REJECTED" "reason=invalid_id | id=$quarantine_id" ## FIX: C6-M-17
+        return 1 ## FIX: C6-M-17
+    fi ## FIX: C6-M-17
+
     local quarantine_path="${QUARANTINE_DIR}/${quarantine_id}"
 
     if [ ! -d "$quarantine_path" ]; then

--- a/scripts/supply-chain/skill_integrity_monitor.sh
+++ b/scripts/supply-chain/skill_integrity_monitor.sh
@@ -166,6 +166,27 @@ is_valid_ere() {
     return 0
 }
 
+# Portable path canonicalization for the C6-M-17 restore-origin checks. GNU `realpath -m` ## FIX: C6-M-17
+# is coreutils-specific (absent/different on BSD/macOS, and busybox realpath has no -m), so ## FIX: C6-M-17
+# fall back to python3 — os.path.realpath resolves symlinks AND tolerates a non-existent ## FIX: C6-M-17
+# trailing component. Prints the canonical path (rc 0); if neither tool is usable it prints ## FIX: C6-M-17
+# nothing (rc 1) so callers fail safe (origin capture skipped -> restore falls closed). ## FIX: C6-M-17
+canonicalize_path() { ## FIX: C6-M-17
+    local p=$1 out ## FIX: C6-M-17
+    # Accept a backend's output only if it is a sane absolute POSIX path (starts with '/'). ## FIX: C6-M-17
+    # This rejects a busybox realpath that mishandles -m, and a Windows python3 that would ## FIX: C6-M-17
+    # emit a C:\ path — so a foreign/garbage value never feeds the restore security checks. ## FIX: C6-M-17
+    if out=$(realpath -m -- "$p" 2>/dev/null) && [ -n "$out" ] && [ "${out#/}" != "$out" ]; then ## FIX: C6-M-17
+        printf '%s\n' "$out"; return 0 ## FIX: C6-M-17
+    fi ## FIX: C6-M-17
+    if command -v python3 >/dev/null 2>&1 \
+       && out=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$p" 2>/dev/null) \
+       && [ -n "$out" ] && [ "${out#/}" != "$out" ]; then ## FIX: C6-M-17
+        printf '%s\n' "$out"; return 0 ## FIX: C6-M-17
+    fi ## FIX: C6-M-17
+    return 1 ## FIX: C6-M-17
+} ## FIX: C6-M-17
+
 # ============================================================================
 # INITIALIZATION
 # ============================================================================
@@ -179,7 +200,7 @@ initialize() {
 
     # Check for required commands
     local missing_cmds=()
-    for cmd in jq sha256sum curl realpath; do ## FIX: C6-M-17 (realpath needed for restore origin canonicalization)
+    for cmd in jq sha256sum curl; do
         if ! command -v "$cmd" &> /dev/null; then
             missing_cmds+=("$cmd")
         fi
@@ -728,7 +749,7 @@ quarantine_skill() {
     # treats the separately-recorded value as authoritative, so a tampered QUARANTINE_INFO.txt ## FIX: C6-M-17
     # cannot redirect the restore target. ## FIX: C6-M-17
     local canonical_origin ## FIX: C6-M-17
-    canonical_origin=$(realpath -- "$skill_path" 2>/dev/null || true) ## FIX: C6-M-17
+    canonical_origin=$(canonicalize_path "$skill_path" 2>/dev/null || true) ## FIX: C6-M-17
 
     # Move skill to quarantine
     if mv "$skill_path" "$quarantine_path"; then
@@ -800,7 +821,7 @@ restore_skill() {
         # canonically (-m: the original location no longer exists once the skill was moved). ## FIX: C6-M-17
         if [ -n "$info_path" ]; then ## FIX: C6-M-17
             local canon_info ## FIX: C6-M-17
-            canon_info=$(realpath -m -- "$info_path" 2>/dev/null || echo "$info_path") ## FIX: C6-M-17
+            canon_info=$(canonicalize_path "$info_path" 2>/dev/null || echo "$info_path") ## FIX: C6-M-17
             if [ "$canon_info" != "$authoritative" ]; then ## FIX: C6-M-17
                 error "Refusing restore: QUARANTINE_INFO.txt path ($info_path) disagrees with recorded origin ($authoritative) — possible tampering" ## FIX: C6-M-17
                 audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=tamper | info=$info_path | recorded=$authoritative" ## FIX: C6-M-17
@@ -842,15 +863,15 @@ restore_skill() {
     # swapped in between quarantine and restore to redirect the mv outside the recorded root. ## FIX: C6-M-17
     local target_parent real_parent ## FIX: C6-M-17
     target_parent=$(dirname -- "$target") ## FIX: C6-M-17
-    real_parent=$(realpath -- "$target_parent" 2>/dev/null || true) ## FIX: C6-M-17
-    if [ -z "$real_parent" ]; then ## FIX: C6-M-17
+    if [ ! -d "$target_parent" ]; then ## FIX: C6-M-17 (explicit: canonicalize_path uses -m and won't error on a missing dir)
         error "Refusing restore: target parent directory does not exist: $target_parent" ## FIX: C6-M-17
         audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=parent_missing | path=$target" ## FIX: C6-M-17
         return 1 ## FIX: C6-M-17
     fi ## FIX: C6-M-17
-    if [ "$real_parent" != "$target_parent" ]; then ## FIX: C6-M-17
-        error "Refusing restore: target parent resolves elsewhere (symlink?): $target_parent -> $real_parent" ## FIX: C6-M-17
-        audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=parent_symlink | path=$target | resolved=$real_parent" ## FIX: C6-M-17
+    real_parent=$(canonicalize_path "$target_parent" 2>/dev/null || true) ## FIX: C6-M-17
+    if [ -z "$real_parent" ] || [ "$real_parent" != "$target_parent" ]; then ## FIX: C6-M-17
+        error "Refusing restore: target parent resolves elsewhere or is unresolvable (symlink?): $target_parent -> ${real_parent:-<none>}" ## FIX: C6-M-17
+        audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=parent_symlink | path=$target | resolved=${real_parent:-none}" ## FIX: C6-M-17
         return 1 ## FIX: C6-M-17
     fi ## FIX: C6-M-17
 

--- a/tests/integration/test_skill_restore_origin.py
+++ b/tests/integration/test_skill_restore_origin.py
@@ -1,0 +1,179 @@
+"""C6-M-17 regression tests — restore_skill origin-ledger hardening.
+
+Claim (issue #123):
+  restore_skill must restore a quarantined skill to the location captured at
+  quarantine time, recorded SEPARATELY from the (tamperable) QUARANTINE_INFO.txt.
+  A rewritten QUARANTINE_INFO.txt must NOT be able to redirect the restore, an
+  untracked quarantine must fail closed unless ALLOW_UNTRACKED_RESTORE=1, and a
+  symlink swapped into the target's parent between quarantine and restore must
+  be rejected.
+
+These drive the real bash functions (quarantine_skill / restore_skill) by sourcing
+scripts/supply-chain/skill_integrity_monitor.sh with its `main` dispatch suppressed,
+inside an isolated sandbox (QUARANTINE_DIR / QUARANTINE_ORIGINS_DIR / OPENCLAW_LOGS
+overridden). Mirrors the bash-mount-path handling used by test_cycle5_claim_regressions.
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MONITOR_SCRIPT = _REPO_ROOT / "scripts" / "supply-chain" / "skill_integrity_monitor.sh"
+_BASH_PATH = shutil.which("bash")
+
+
+def _detect_bash_mount_root(bash_path: str | None) -> str:
+    """WSL mounts C: at /mnt/c; Git Bash / MSYS / Cygwin mount it at /c."""
+    if not bash_path:
+        return "/mnt/"
+    try:
+        proc = subprocess.run(
+            [bash_path, "--version"], capture_output=True, text=True, check=False, timeout=5
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "/mnt/"
+    banner = (proc.stdout + proc.stderr).lower()
+    if "cygwin" in banner or "msys" in banner or "mingw" in banner:
+        return "/"
+    return "/mnt/"
+
+
+def _to_bash_path(path: Path, bash_path: str | None = None) -> str:
+    """Convert an absolute path to the bash mount path for this flavor."""
+    if sys.platform != "win32":
+        return path.as_posix()
+    drive_letter = path.drive.rstrip(":").lower()
+    rest = path.as_posix()[len(path.drive):]
+    return f"{_detect_bash_mount_root(bash_path)}{drive_letter}{rest}"
+
+
+def _can_make_resolvable_symlink() -> bool:
+    """True iff this platform can create a symlink that realpath resolves
+    (Windows/MSYS without Developer Mode cannot — the symlink case is skipped there)."""
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            target = Path(d) / "target"
+            link = Path(d) / "link"
+            target.mkdir()
+            os.symlink(target, link)
+            return Path(os.path.realpath(link)) == target.resolve()
+    except (OSError, NotImplementedError):
+        return False
+
+
+_CAN_SYMLINK = _can_make_resolvable_symlink()
+
+# Bash driver: sources the monitor script (main suppressed), isolates the quarantine
+# + origin-ledger dirs into the sandbox, then runs one named scenario and prints
+# RC= plus scenario markers and the audit log.
+_DRIVER = r'''
+SCRIPT="$1"; SB="$2"; SCEN="$3"
+export OPENCLAW_LOGS="$SB/logs"
+mkdir -p "$SB/logs" "$SB/q" "$SB/origins" "$SB/skills"
+sed 's/^main "\$@"$/: # main suppressed/' "$SCRIPT" > "$SB/mon.sh"
+# shellcheck disable=SC1090
+source "$SB/mon.sh"
+set +e +u +o pipefail
+QUARANTINE_DIR="$SB/q"
+QUARANTINE_ORIGINS_DIR="$SB/origins"
+_grep_qid() { ls -1 "$SB/q" | grep -F "$1" | head -n1; }
+
+case "$SCEN" in
+  tracked)
+    mkdir -p "$SB/skills/sk one"; echo d > "$SB/skills/sk one/f"
+    quarantine_skill "$SB/skills/sk one" t >/dev/null 2>&1
+    qid=$(_grep_qid "sk one")
+    restore_skill "$qid" >/dev/null 2>&1; echo "RC=$?"
+    [ -f "$SB/skills/sk one/f" ] && echo "RESTORED=yes" || echo "RESTORED=no" ;;
+  tamper)
+    mkdir -p "$SB/skills/tsk"; echo d > "$SB/skills/tsk/f"
+    quarantine_skill "$SB/skills/tsk" t >/dev/null 2>&1
+    qid=$(_grep_qid "tsk")
+    sed -i "s#^Original Path:.*#Original Path: $SB/evil#" "$SB/q/$qid/QUARANTINE_INFO.txt"
+    restore_skill "$qid" >/dev/null 2>&1; echo "RC=$?"
+    [ -e "$SB/evil" ] && echo "EVIL=created" || echo "EVIL=absent"
+    [ -d "$SB/q/$qid" ] && echo "QDIR=intact" || echo "QDIR=gone" ;;
+  untracked)
+    mkdir -p "$SB/skills/usk"; echo d > "$SB/skills/usk/f"
+    quarantine_skill "$SB/skills/usk" t >/dev/null 2>&1
+    qid=$(_grep_qid "usk"); rm -f "$SB/origins/$qid"
+    restore_skill "$qid" >/dev/null 2>&1; echo "RC=$?" ;;
+  untracked_flag)
+    mkdir -p "$SB/skills/ufsk"; echo d > "$SB/skills/ufsk/f"
+    quarantine_skill "$SB/skills/ufsk" t >/dev/null 2>&1
+    qid=$(_grep_qid "ufsk"); rm -f "$SB/origins/$qid"
+    ALLOW_UNTRACKED_RESTORE=1 restore_skill "$qid" >/dev/null 2>&1; echo "RC=$?"
+    [ -f "$SB/skills/ufsk/f" ] && echo "RESTORED=yes" || echo "RESTORED=no" ;;
+  symlink)
+    mkdir -p "$SB/skills/realdir/ssk"; echo d > "$SB/skills/realdir/ssk/f"
+    quarantine_skill "$SB/skills/realdir/ssk" t >/dev/null 2>&1
+    qid=$(_grep_qid "ssk")
+    rm -rf "$SB/skills/realdir"; mkdir -p "$SB/evil2"; ln -s "$SB/evil2" "$SB/skills/realdir"
+    restore_skill "$qid" >/dev/null 2>&1; echo "RC=$?"
+    [ -e "$SB/evil2/ssk" ] && echo "EVIL=landed" || echo "EVIL=clean" ;;
+esac
+echo "AUDIT<<"; cat "$SB/logs/skill_audit.log" 2>/dev/null; echo ">>AUDIT"
+'''
+
+
+def _run(scenario: str, tmp_path: Path) -> str:
+    assert _BASH_PATH, "bash is required for these tests"
+    sandbox = tmp_path / "sb"
+    sandbox.mkdir()
+    out = subprocess.run(
+        [
+            _BASH_PATH, "-c", _DRIVER, "driver",
+            _to_bash_path(_MONITOR_SCRIPT, _BASH_PATH),
+            _to_bash_path(sandbox, _BASH_PATH),
+            scenario,
+        ],
+        capture_output=True, text=True, check=False, timeout=60,
+    )
+    return out.stdout + out.stderr
+
+
+pytestmark = pytest.mark.skipif(_BASH_PATH is None, reason="bash not available")
+
+
+def test_tracked_roundtrip_with_spaces_restores_to_origin(tmp_path):
+    """Happy path (incl. spaces / M-06 invariant): a tracked quarantine restores."""
+    out = _run("tracked", tmp_path)
+    assert "RC=0" in out, out
+    assert "RESTORED=yes" in out, out
+
+
+def test_tampered_quarantine_info_is_rejected(tmp_path):
+    """A rewritten Original Path that disagrees with the recorded origin -> reject, no mv."""
+    out = _run("tamper", tmp_path)
+    assert "RC=1" in out, out
+    assert "EVIL=absent" in out, out          # mv did not follow the tampered path
+    assert "QDIR=intact" in out, out          # quarantine not consumed
+    assert "reason=tamper" in out, out
+
+
+def test_untracked_quarantine_fails_closed_by_default(tmp_path):
+    """No origin record -> refuse by default."""
+    out = _run("untracked", tmp_path)
+    assert "RC=1" in out, out
+    assert "reason=untracked" in out, out
+
+
+def test_untracked_with_optout_flag_restores(tmp_path):
+    """ALLOW_UNTRACKED_RESTORE=1 falls back to QUARANTINE_INFO + shape checks."""
+    out = _run("untracked_flag", tmp_path)
+    assert "RC=0" in out, out
+    assert "RESTORED=yes" in out, out
+
+
+@pytest.mark.skipif(not _CAN_SYMLINK, reason="platform cannot create resolvable symlinks")
+def test_symlink_swapped_parent_is_rejected(tmp_path):
+    """A symlink swapped into the target's parent after quarantine -> reject, nothing escapes."""
+    out = _run("symlink", tmp_path)
+    assert "RC=1" in out, out
+    assert "EVIL=clean" in out, out
+    assert "reason=parent_symlink" in out, out

--- a/tests/integration/test_skill_restore_origin.py
+++ b/tests/integration/test_skill_restore_origin.py
@@ -75,9 +75,10 @@ _DRIVER = r'''
 SCRIPT="$1"; SB="$2"; SCEN="$3"
 export OPENCLAW_LOGS="$SB/logs"
 mkdir -p "$SB/logs" "$SB/q" "$SB/origins" "$SB/skills"
-sed 's/^main "\$@"$/: # main suppressed/' "$SCRIPT" > "$SB/mon.sh"
+# Sourcing defines the functions without running main (BASH_SOURCE guard in the script),
+# so no sed-based suppression is needed.
 # shellcheck disable=SC1090
-source "$SB/mon.sh"
+source "$SCRIPT"
 set +e +u +o pipefail
 QUARANTINE_DIR="$SB/q"
 QUARANTINE_ORIGINS_DIR="$SB/origins"
@@ -94,7 +95,7 @@ case "$SCEN" in
     mkdir -p "$SB/skills/tsk"; echo d > "$SB/skills/tsk/f"
     quarantine_skill "$SB/skills/tsk" t >/dev/null 2>&1
     qid=$(_grep_qid "tsk")
-    sed -i "s#^Original Path:.*#Original Path: $SB/evil#" "$SB/q/$qid/QUARANTINE_INFO.txt"
+    printf 'Original Path: %s\n' "$SB/evil" > "$SB/q/$qid/QUARANTINE_INFO.txt"
     restore_skill "$qid" >/dev/null 2>&1; echo "RC=$?"
     [ -e "$SB/evil" ] && echo "EVIL=created" || echo "EVIL=absent"
     [ -d "$SB/q/$qid" ] && echo "QDIR=intact" || echo "QDIR=gone" ;;

--- a/tests/integration/test_skill_restore_origin.py
+++ b/tests/integration/test_skill_restore_origin.py
@@ -79,10 +79,19 @@ mkdir -p "$SB/logs" "$SB/q" "$SB/origins" "$SB/skills"
 # so no sed-based suppression is needed.
 # shellcheck disable=SC1090
 source "$SCRIPT"
-set +e +u +o pipefail
+# errexit OFF: restore_skill returns non-zero on every rejection path and we capture $?
+# (with -e on, `restore_skill ...; echo "RC=$?"` would abort before the echo). nounset and
+# pipefail stay ON so unset-var bugs and pipe failures in the driver surface attributably.
+set +e
 QUARANTINE_DIR="$SB/q"
 QUARANTINE_ORIGINS_DIR="$SB/origins"
-_grep_qid() { ls -1 "$SB/q" | grep -F "$1" | head -n1; }
+# Fail loudly (and attributably) if no quarantine id matches, rather than silently using "".
+_grep_qid() {
+    local id
+    id=$(ls -1 "$SB/q" | grep -F "$1" | head -n1)
+    [ -n "$id" ] || { echo "DRIVER_ERROR: no quarantine id matching '$1' (scenario=$SCEN)" >&2; exit 3; }
+    printf '%s\n' "$id"
+}
 
 case "$SCEN" in
   tracked)

--- a/tests/integration/test_skill_restore_origin.py
+++ b/tests/integration/test_skill_restore_origin.py
@@ -116,6 +116,9 @@ case "$SCEN" in
     rm -rf "$SB/skills/realdir"; mkdir -p "$SB/evil2"; ln -s "$SB/evil2" "$SB/skills/realdir"
     restore_skill "$qid" >/dev/null 2>&1; echo "RC=$?"
     [ -e "$SB/evil2/ssk" ] && echo "EVIL=landed" || echo "EVIL=clean" ;;
+  invalid_id)
+    restore_skill "../../escape" >/dev/null 2>&1; echo "RC_slash=$?"
+    restore_skill ".." >/dev/null 2>&1; echo "RC_dotdot=$?" ;;
 esac
 echo "AUDIT<<"; cat "$SB/logs/skill_audit.log" 2>/dev/null; echo ">>AUDIT"
 '''
@@ -177,3 +180,11 @@ def test_symlink_swapped_parent_is_rejected(tmp_path):
     assert "RC=1" in out, out
     assert "EVIL=clean" in out, out
     assert "reason=parent_symlink" in out, out
+
+
+def test_path_traversal_quarantine_id_is_rejected(tmp_path):
+    """A --restore id containing '/' or '..' is rejected before any path is built or rm-ed."""
+    out = _run("invalid_id", tmp_path)
+    assert "RC_slash=1" in out, out
+    assert "RC_dotdot=1" in out, out
+    assert "reason=invalid_id" in out, out

--- a/tests/integration/test_skill_restore_origin.py
+++ b/tests/integration/test_skill_restore_origin.py
@@ -119,6 +119,16 @@ case "$SCEN" in
   invalid_id)
     restore_skill "../../escape" >/dev/null 2>&1; echo "RC_slash=$?"
     restore_skill ".." >/dev/null 2>&1; echo "RC_dotdot=$?" ;;
+  empty_record)
+    mkdir -p "$SB/skills/esk"; echo d > "$SB/skills/esk/f"
+    quarantine_skill "$SB/skills/esk" t >/dev/null 2>&1
+    qid=$(_grep_qid "esk"); : > "$SB/origins/$qid"   # truncate the ledger to empty
+    restore_skill "$qid" >/dev/null 2>&1; echo "RC=$?" ;;
+  parent_missing)
+    mkdir -p "$SB/skills/realp/psk"; echo d > "$SB/skills/realp/psk/f"
+    quarantine_skill "$SB/skills/realp/psk" t >/dev/null 2>&1
+    qid=$(_grep_qid "psk"); rm -rf "$SB/skills/realp"   # remove the recorded target's parent
+    restore_skill "$qid" >/dev/null 2>&1; echo "RC=$?" ;;
 esac
 echo "AUDIT<<"; cat "$SB/logs/skill_audit.log" 2>/dev/null; echo ">>AUDIT"
 '''
@@ -188,3 +198,17 @@ def test_path_traversal_quarantine_id_is_rejected(tmp_path):
     assert "RC_slash=1" in out, out
     assert "RC_dotdot=1" in out, out
     assert "reason=invalid_id" in out, out
+
+
+def test_empty_origin_record_is_rejected(tmp_path):
+    """A present-but-empty origin ledger -> reject (cannot trust an empty authoritative path)."""
+    out = _run("empty_record", tmp_path)
+    assert "RC=1" in out, out
+    assert "reason=empty_origin_record" in out, out
+
+
+def test_missing_target_parent_is_rejected(tmp_path):
+    """Recorded target's parent removed before restore -> reject (no mv into a vanished tree)."""
+    out = _run("parent_missing", tmp_path)
+    assert "RC=1" in out, out
+    assert "reason=parent_missing" in out, out


### PR DESCRIPTION
Implement a robust origin tracking mechanism for restore_skill to prevent tampering with QUARANTINE_INFO.txt. This update introduces an integrity-protected origin record stored separately from the tamperable metadata, ensuring that any modifications to the quarantine information do not affect the restore process. The changes include validation of quarantine IDs and checks against symlink manipulation, enhancing security against potential exploits. New regression tests cover various rejection scenarios, ensuring the integrity of the restore process remains intact.
Closes the residual risk from C6-M-14 (#99)