### PR TITLE
fix(C6-RT-02): add mixed-line-ending pre-commit guard enforcing LF working-tree endings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,5 @@ repos:
     rev: v5.0.0  # FIX: C6-L-02
     hooks:  # FIX: C6-L-02
       - id: check-merge-conflict  # FIX: C6-L-02
+      - id: mixed-line-ending  # FIX: C6-RT-02: durable LF guard — `git ls-files --eol` can't flag CRLF that the index already normalized, so enforce it in the working tree at commit time
+        args: [--fix=lf]  # FIX: C6-RT-02


### PR DESCRIPTION
Four .sh files (build_timeline.sh, collect_evidence.sh, wireguard_setup.sh, os-scan.sh) were CRLF in the Windows working tree but already LF in the git index (.gitattributes normalizes *.sh eol=lf on commit). That state is invisible to `git status` and `git ls-files --eol` (the index is already LF), so neither a CI index check nor a developer would notice until a Windows edit committed CRLF-contaminated lines.

Add the standard `mixed-line-ending --fix=lf` hook to the existing pre-commit-hooks block (rev v5.0.0) as a durable, repo-enforced guard that rewrites any staged CRLF to LF at commit time. Aligns with the tree-wide `.gitattributes` eol=lf policy; no CRLF exceptions exist, so no churn risk.

The companion working-tree re-checkout of the 4 .sh files is operational (it produces no committable change since the index is already LF) and is not part of this commit.