### PR TITLE
fix(C6-RT-01): verify_hash_chain now recomputes content hash and rejects tampered events

### DIFF
--- a/scripts/forensics/verify_hash_chain.py
+++ b/scripts/forensics/verify_hash_chain.py
@@ -10,6 +10,7 @@ Exits with code 0 if chain is intact, code 1 if tampering detected.
 Part of: https://github.com/topazyo/openclaw-security-playbook
 """
 
+import hashlib  # FIX: C6-RT-01 - recompute event content hashes, not just the prev_hash pointer
 import json
 import sys
 import argparse
@@ -53,33 +54,55 @@ def verify_hash_chain(input_path: str, output_path: str | None = None) -> bool:
         "last_event": events[-1].get("timestamp"),
     }
 
-    prev_hash: str | None = None
+    prev_chain_hash: str | None = None  # FIX: C6-RT-01 - stored chain_hash of the previous event
 
     for i, event in enumerate(events):
-        current_hash = event.get("chain_hash")
+        stored_chain_hash = event.get("chain_hash")  # FIX: C6-RT-01
         event_prev_hash = event.get("prev_hash")
 
-        if i == 0:
-            prev_hash = current_hash
-            continue
+        # FIX: C6-RT-01 - Recompute the content hash exactly as the canonical writer
+        # (apply_hash_chain) produced it: SHA-256 over the event object WITHOUT chain_hash,
+        # with prev_hash retained in the hashed body, canonicalized via json.dumps(sort_keys=True).
+        # The previous logic only compared the stored prev_hash pointer, so editing an event's
+        # content while preserving prev_hash/chain_hash passed as "intact". Fail closed: any
+        # content mismatch, missing/invalid chain_hash, or broken linkage is recorded as a break.
+        recomputed_chain_hash: str | None = None  # FIX: C6-RT-01
+        break_reason: str | None = None  # FIX: C6-RT-01
+        if not isinstance(stored_chain_hash, str) or not stored_chain_hash:  # FIX: C6-RT-01
+            break_reason = "missing_or_invalid_chain_hash"  # FIX: C6-RT-01
+        else:  # FIX: C6-RT-01
+            hashed_body = {k: v for k, v in event.items() if k != "chain_hash"}  # FIX: C6-RT-01
+            recomputed_chain_hash = hashlib.sha256(  # FIX: C6-RT-01
+                json.dumps(hashed_body, sort_keys=True).encode("utf-8")  # FIX: C6-RT-01
+            ).hexdigest()  # FIX: C6-RT-01
+            if recomputed_chain_hash != stored_chain_hash:  # FIX: C6-RT-01 - content tampering
+                break_reason = "content_hash_mismatch"  # FIX: C6-RT-01
+            elif i == 0:  # FIX: C6-RT-01 - genesis event must declare prev_hash=null
+                if event_prev_hash is not None:  # FIX: C6-RT-01
+                    break_reason = "genesis_prev_hash_not_null"  # FIX: C6-RT-01
+            elif event_prev_hash != prev_chain_hash:  # FIX: C6-RT-01 - linkage to prior event
+                break_reason = "prev_hash_link_mismatch"  # FIX: C6-RT-01
 
-        if prev_hash is not None and event_prev_hash != prev_hash:
+        if break_reason is not None:  # FIX: C6-RT-01 - fail closed on any unverifiable/tampered event
             break_info: JsonObject = {
                 "position": i,
                 "timestamp": event.get("timestamp"),
-                "expected_prev_hash": prev_hash,
+                "reason": break_reason,  # FIX: C6-RT-01
+                "expected_prev_hash": prev_chain_hash if i > 0 else None,  # FIX: C6-RT-01
                 "actual_prev_hash": event_prev_hash,
+                "stored_chain_hash": stored_chain_hash,  # FIX: C6-RT-01
+                "recomputed_chain_hash": recomputed_chain_hash,  # FIX: C6-RT-01
                 "event_type": event.get("event_type"),
             }
             results["breaks"].append(break_info)
             results["chain_intact"] = False
             print(
-                f"BREAK at position {i} ({event.get('timestamp')}): "
-                f"expected prev_hash={prev_hash}, got={event_prev_hash}",
+                f"BREAK at position {i} ({event.get('timestamp')}): {break_reason} "  # FIX: C6-RT-01
+                f"(stored={stored_chain_hash}, recomputed={recomputed_chain_hash})",  # FIX: C6-RT-01
                 file=sys.stderr,
             )
 
-        prev_hash = current_hash
+        prev_chain_hash = stored_chain_hash  # FIX: C6-RT-01 - advance to this event's stored hash
 
     if output_path:
         with open(output_path, "w") as f:

--- a/scripts/forensics/verify_hash_chain.py
+++ b/scripts/forensics/verify_hash_chain.py
@@ -22,6 +22,42 @@ from typing import Any
 JsonObject = dict[str, Any]
 
 
+def compute_event_chain_hash(event: JsonObject) -> str:  # FIX: C6-RT-01 - single source of truth for the content hash
+    """Canonical chain_hash for one telemetry event.
+
+    SHA-256 over the event object EXCLUDING its own ``chain_hash`` (``prev_hash`` is retained
+    in the hashed body), canonicalized via ``json.dumps(sort_keys=True)``. This mirrors the
+    canonical writer ``exercise_malicious_skill_chain.apply_hash_chain``. It is the sole place
+    the verifier recomputes the hash and is imported by the tests, so the verifier and its
+    fixtures cannot drift apart; writer-vs-verifier agreement is pinned separately by the
+    intact-chain test that builds fixtures with the real writer.
+    """
+    hashed_body = {k: v for k, v in event.items() if k != "chain_hash"}  # FIX: C6-RT-01
+    return hashlib.sha256(json.dumps(hashed_body, sort_keys=True).encode("utf-8")).hexdigest()  # FIX: C6-RT-01
+
+
+def _short_hash(value: object, prefix: int = 12) -> str:  # FIX: C6-RT-01 - keep the human-facing stderr line scannable
+    """Render a hash/pointer for the stderr break message.
+
+    Truncates 64-char hex digests to a leading prefix so a multi-break run stays readable;
+    ``None`` is shown as ``null``. The untruncated values are always preserved in full in the
+    JSON report's ``breaks`` entries, so field debugging loses nothing when ``--output`` is set.
+    """
+    if value is None:  # FIX: C6-RT-01
+        return "null"  # FIX: C6-RT-01
+    text = str(value)  # FIX: C6-RT-01
+    return f"{text[:prefix]}..." if len(text) > prefix else text  # FIX: C6-RT-01
+
+
+def _is_valid_chain_hash(value: object) -> bool:  # FIX: C6-RT-01 - a present, non-empty string is the only verifiable chain_hash
+    """Whether a stored chain_hash is verifiable at all (present, a string, non-empty).
+
+    An event whose own chain_hash fails this cannot be content-verified, and the NEXT event
+    cannot have its linkage meaningfully checked against it — see the linkage gate below.
+    """
+    return isinstance(value, str) and bool(value)  # FIX: C6-RT-01
+
+
 def verify_hash_chain(input_path: str, output_path: str | None = None) -> bool:
     events: list[JsonObject] = []
     path = Path(input_path)
@@ -68,18 +104,17 @@ def verify_hash_chain(input_path: str, output_path: str | None = None) -> bool:
         # content mismatch, missing/invalid chain_hash, or broken linkage is recorded as a break.
         recomputed_chain_hash: str | None = None  # FIX: C6-RT-01
         break_reason: str | None = None  # FIX: C6-RT-01
-        if not isinstance(stored_chain_hash, str) or not stored_chain_hash:  # FIX: C6-RT-01
+        if not _is_valid_chain_hash(stored_chain_hash):  # FIX: C6-RT-01 - this event is unverifiable
             break_reason = "missing_or_invalid_chain_hash"  # FIX: C6-RT-01
         else:  # FIX: C6-RT-01
-            hashed_body = {k: v for k, v in event.items() if k != "chain_hash"}  # FIX: C6-RT-01
-            recomputed_chain_hash = hashlib.sha256(  # FIX: C6-RT-01
-                json.dumps(hashed_body, sort_keys=True).encode("utf-8")  # FIX: C6-RT-01
-            ).hexdigest()  # FIX: C6-RT-01
+            recomputed_chain_hash = compute_event_chain_hash(event)  # FIX: C6-RT-01 - canonical content hash
             if recomputed_chain_hash != stored_chain_hash:  # FIX: C6-RT-01 - content tampering
                 break_reason = "content_hash_mismatch"  # FIX: C6-RT-01
             elif i == 0:  # FIX: C6-RT-01 - genesis event must declare prev_hash=null
                 if event_prev_hash is not None:  # FIX: C6-RT-01
                     break_reason = "genesis_prev_hash_not_null"  # FIX: C6-RT-01
+            elif not _is_valid_chain_hash(prev_chain_hash):  # FIX: C6-RT-01 - prior event unverifiable, so linkage can't be checked
+                break_reason = "previous_event_unverifiable"  # FIX: C6-RT-01 - distinct from a genuine link mismatch
             elif event_prev_hash != prev_chain_hash:  # FIX: C6-RT-01 - linkage to prior event
                 break_reason = "prev_hash_link_mismatch"  # FIX: C6-RT-01
 
@@ -97,8 +132,12 @@ def verify_hash_chain(input_path: str, output_path: str | None = None) -> bool:
             results["breaks"].append(break_info)
             results["chain_intact"] = False
             print(
-                f"BREAK at position {i} ({event.get('timestamp')}): {break_reason} "  # FIX: C6-RT-01
-                f"(stored={stored_chain_hash}, recomputed={recomputed_chain_hash})",  # FIX: C6-RT-01
+                f"BREAK at position {i} ({event.get('timestamp')}, "  # FIX: C6-RT-01
+                f"event_type={event.get('event_type')}): {break_reason} "  # FIX: C6-RT-01 - include event_type
+                f"[expected_prev_hash={_short_hash(prev_chain_hash if i > 0 else None)}, "  # FIX: C6-RT-01 - restore linkage detail
+                f"actual_prev_hash={_short_hash(event_prev_hash)}, "  # FIX: C6-RT-01 - restore linkage detail
+                f"stored_chain_hash={_short_hash(stored_chain_hash)}, "  # FIX: C6-RT-01
+                f"recomputed_chain_hash={_short_hash(recomputed_chain_hash)}]",  # FIX: C6-RT-01
                 file=sys.stderr,
             )
 

--- a/tests/security/test_verify_hash_chain.py
+++ b/tests/security/test_verify_hash_chain.py
@@ -12,7 +12,6 @@ the stored ``prev_hash`` pointer, so content edits that preserved the pointer pa
 from __future__ import annotations
 
 import copy
-import hashlib
 import importlib.util
 import json
 import sys
@@ -66,10 +65,12 @@ def _write_jsonl(tmp_path: Path, events: list[dict[str, Any]]) -> str:
     return str(path)
 
 
-def _rehash(event: dict[str, Any]) -> str:
-    """Recompute an event's chain_hash the way the canonical writer does."""
-    body = {k: v for k, v in event.items() if k != "chain_hash"}
-    return hashlib.sha256(json.dumps(body, sort_keys=True).encode("utf-8")).hexdigest()
+# Re-hash via the verifier's own canonical routine (the single source of truth) rather than a
+# duplicated copy here, so a fixture built to pass the content check can never drift from what
+# the verifier actually computes. These re-hashes only exist to make the content check pass so
+# the linkage/genesis checks can be isolated; writer-vs-verifier agreement is pinned separately
+# by test_accepts_intact_chain_from_canonical_writer below.
+_rehash = verifier.compute_event_chain_hash
 
 
 def test_accepts_intact_chain_from_canonical_writer(tmp_path: Path) -> None:
@@ -113,6 +114,25 @@ def test_fails_closed_on_missing_chain_hash(tmp_path: Path) -> None:
 
     report = json.loads(Path(report_path).read_text(encoding="utf-8"))
     assert any(b["position"] == 1 and b["reason"] == "missing_or_invalid_chain_hash" for b in report["breaks"])
+
+
+def test_unverifiable_previous_event_is_not_mislabeled_as_link_mismatch(tmp_path: Path) -> None:
+    # When a prior event is unverifiable (missing chain_hash), the NEXT event's linkage cannot be
+    # meaningfully checked: its prev_hash points at the prior event's real hash, but the verifier
+    # has no verified hash to compare against. It must be reported as previous_event_unverifiable,
+    # NOT as a genuine prev_hash_link_mismatch. (Event 3's own content is left intact so it does
+    # not trip content_hash_mismatch first, isolating the linkage path.)
+    events = copy.deepcopy(_build_chain())
+    del events[2]["chain_hash"]  # event 2 becomes unverifiable; events 0,1,3,4 untouched
+    report_path = str(tmp_path / "report.json")
+    assert verifier.verify_hash_chain(_write_jsonl(tmp_path, events), report_path) is False
+
+    report = json.loads(Path(report_path).read_text(encoding="utf-8"))
+    by_position = {b["position"]: b["reason"] for b in report["breaks"]}
+    assert by_position.get(2) == "missing_or_invalid_chain_hash"
+    assert by_position.get(3) == "previous_event_unverifiable"
+    # The bug this guards against: event 3 must NOT be blamed for a link mismatch it didn't cause.
+    assert not any(b["position"] == 3 and b["reason"] == "prev_hash_link_mismatch" for b in report["breaks"])
 
 
 def test_rejects_prev_hash_link_tamper_even_when_content_hash_valid(tmp_path: Path) -> None:

--- a/tests/security/test_verify_hash_chain.py
+++ b/tests/security/test_verify_hash_chain.py
@@ -24,11 +24,22 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _load(module_path: Path, module_name: str):
-    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    # Load a source file as a throwaway module WITHOUT leaving it in the global module
+    # cache. The entry is registered only for the duration of exec_module (so a module that
+    # imports itself by name still resolves) under a name namespaced to THIS test module,
+    # then removed in finally. Registering under the source file's canonical name instead
+    # would (a) leak module state — globals, monkeypatches — across tests and (b) collide
+    # with other tests that load the same file under that name (e.g.
+    # test_malicious_skill_chain_exercise also registers "exercise_malicious_skill_chain").
+    qualified_name = f"{__name__}.{module_name}"
+    spec = importlib.util.spec_from_file_location(qualified_name, module_path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
+    sys.modules[qualified_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(qualified_name, None)
     return module
 
 

--- a/tests/security/test_verify_hash_chain.py
+++ b/tests/security/test_verify_hash_chain.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Adversarial tests for the forensic hash-chain verifier (finding C6-RT-01).
+
+These prove WRITER-COMPATIBILITY, not self-consistency: the intact fixture is built
+with the canonical writer ``exercise_malicious_skill_chain.apply_hash_chain`` (the sole
+producer of ``chain_hash``/``prev_hash`` in the repo), and the verifier must accept it
+while rejecting any event whose *content* was tampered — including the genesis event —
+and failing closed on unverifiable events. Before C6-RT-01 the verifier only compared
+the stored ``prev_hash`` pointer, so content edits that preserved the pointer passed.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(module_path: Path, module_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# The canonical writer (apply_hash_chain / build_incident_events) and the verifier under test.
+exercise = _load(
+    REPO_ROOT / "scripts" / "verification" / "exercise_malicious_skill_chain.py",
+    "exercise_malicious_skill_chain",
+)
+verifier = _load(
+    REPO_ROOT / "scripts" / "forensics" / "verify_hash_chain.py",
+    "verify_hash_chain_under_test",
+)
+
+
+def _build_chain() -> list[dict[str, Any]]:
+    """A realistic, correctly hash-chained incident produced by the canonical writer."""
+    return exercise.build_incident_events("INC-TEST-C6RT01")
+
+
+def _write_jsonl(tmp_path: Path, events: list[dict[str, Any]]) -> str:
+    # Mirror exercise_malicious_skill_chain's telemetry writer: one json.dumps line per event.
+    path = tmp_path / "telemetry.jsonl"
+    path.write_text("".join(json.dumps(event) + "\n" for event in events), encoding="utf-8")
+    return str(path)
+
+
+def _rehash(event: dict[str, Any]) -> str:
+    """Recompute an event's chain_hash the way the canonical writer does."""
+    body = {k: v for k, v in event.items() if k != "chain_hash"}
+    return hashlib.sha256(json.dumps(body, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+def test_accepts_intact_chain_from_canonical_writer(tmp_path: Path) -> None:
+    # WRITER-COMPATIBILITY: a chain straight from apply_hash_chain must verify intact.
+    events = _build_chain()
+    assert verifier.verify_hash_chain(_write_jsonl(tmp_path, events)) is True
+
+
+def test_rejects_non_genesis_content_tamper_with_intact_pointers(tmp_path: Path) -> None:
+    # The exact gap C6-RT-01 closes: edit a non-genesis event's body but leave its stored
+    # prev_hash AND chain_hash untouched. Pointer linkage is still intact, so the old
+    # verifier passed this; the content recomputation must now reject it.
+    events = copy.deepcopy(_build_chain())
+    events[2]["tool_args"] = {"path": "/home/clawdbot/.ssh/id_rsa"}  # tampered content
+    report_path = str(tmp_path / "report.json")
+    assert verifier.verify_hash_chain(_write_jsonl(tmp_path, events), report_path) is False
+
+    report = json.loads(Path(report_path).read_text(encoding="utf-8"))
+    assert report["chain_intact"] is False
+    reasons = {(b["position"], b["reason"]) for b in report["breaks"]}
+    assert (2, "content_hash_mismatch") in reasons
+
+
+def test_rejects_genesis_content_tamper(tmp_path: Path) -> None:
+    # No genesis exemption: event 0's content is hash-verified too.
+    events = copy.deepcopy(_build_chain())
+    events[0]["skill_name"] = "@totally/benign-skill"  # tampered genesis content, hash untouched
+    report_path = str(tmp_path / "report.json")
+    assert verifier.verify_hash_chain(_write_jsonl(tmp_path, events), report_path) is False
+
+    report = json.loads(Path(report_path).read_text(encoding="utf-8"))
+    assert any(b["position"] == 0 and b["reason"] == "content_hash_mismatch" for b in report["breaks"])
+
+
+def test_fails_closed_on_missing_chain_hash(tmp_path: Path) -> None:
+    # An event without a recomputable chain_hash is unverifiable -> must NOT pass by default.
+    events = copy.deepcopy(_build_chain())
+    del events[1]["chain_hash"]
+    report_path = str(tmp_path / "report.json")
+    assert verifier.verify_hash_chain(_write_jsonl(tmp_path, events), report_path) is False
+
+    report = json.loads(Path(report_path).read_text(encoding="utf-8"))
+    assert any(b["position"] == 1 and b["reason"] == "missing_or_invalid_chain_hash" for b in report["breaks"])
+
+
+def test_rejects_prev_hash_link_tamper_even_when_content_hash_valid(tmp_path: Path) -> None:
+    # Linkage is still enforced after the content-hash addition: rewrite a non-genesis event's
+    # prev_hash to a bogus value and RE-HASH it so its own content check passes — the broken
+    # link to the prior event must still be detected.
+    events = copy.deepcopy(_build_chain())
+    events[3]["prev_hash"] = "0" * 64
+    events[3]["chain_hash"] = _rehash(events[3])  # content now self-consistent, but link is wrong
+    report_path = str(tmp_path / "report.json")
+    assert verifier.verify_hash_chain(_write_jsonl(tmp_path, events), report_path) is False
+
+    report = json.loads(Path(report_path).read_text(encoding="utf-8"))
+    assert any(b["position"] == 3 and b["reason"] == "prev_hash_link_mismatch" for b in report["breaks"])
+
+
+def test_rejects_genesis_prev_hash_not_null(tmp_path: Path) -> None:
+    # The genesis event must declare prev_hash=null; a re-hashed event 0 with a non-null
+    # prev_hash is self-consistent on content but violates the genesis convention.
+    events = copy.deepcopy(_build_chain())
+    events[0]["prev_hash"] = "f" * 64
+    events[0]["chain_hash"] = _rehash(events[0])
+    report_path = str(tmp_path / "report.json")
+    assert verifier.verify_hash_chain(_write_jsonl(tmp_path, events), report_path) is False
+
+    report = json.loads(Path(report_path).read_text(encoding="utf-8"))
+    assert any(b["position"] == 0 and b["reason"] == "genesis_prev_hash_not_null" for b in report["breaks"])


### PR DESCRIPTION
verify_hash_chain() previously compared only the stored prev_hash pointer and trusted the genesis event, so editing an event body while preserving prev_hash/chain_hash passed as intact. It now recomputes each event's SHA-256 content hash exactly as the canonical writer (exercise_malicious_skill_chain.apply_hash_chain) produced it - over the event minus chain_hash, with prev_hash retained, canonicalized via json.dumps(sort_keys=True) - for every event including genesis, and fails closed on missing/invalid chain_hash, content mismatch, non-null genesis prev_hash, or broken linkage. Adds tests/security/test_verify_hash_chain.py (6 adversarial cases incl. writer-built intact acceptance). Evidence: writer-built intact chain -> exit 0; non-genesis content tamper -> exit 1; genesis tamper -> exit 1; tests/security 151 passed/2 skipped (was 145/2 + 6 new). Residual (out of scope): whole-chain rewrite needs external anchoring.