### PR TITLE
fix(C6-RT-03): block_ip dry-run no longer requires AWS credentials before simulation

### DIFF
--- a/scripts/incident-response/auto-containment.py
+++ b/scripts/incident-response/auto-containment.py
@@ -271,7 +271,19 @@ class ContainmentManager:
         return DNS_FIREWALL_DOMAIN_LIST_ID
 
     def block_ip_address(self, ip_address: str, duration: Optional[str] = None, reason: Optional[str] = None) -> bool:  # FIX: C5-finding-3  # pylance: duration/reason default to None
-        """Block an attacker IP by adding deny entries to the emergency network ACL."""  # FIX: C5-finding-3
+        """Block an attacker IP by adding deny entries to the emergency network ACL.
+
+        Report contract: every action record carries the same top-level keys
+        (timestamp, incident_id, action, target, status, details, dry_run). The
+        ``details`` bag is status-dependent, so consumers MUST branch on ``status``:
+          - ``dry_run``: {cidr_block, duration, reason}. The AWS-derived fields
+            (network_acl_id, ingress_rule_number, egress_rule_number,
+            ingress_already_present, egress_already_present) are intentionally
+            ABSENT — dry-run performs no NACL discovery and requires no AWS
+            credentials (C6-RT-03), so those values are never resolved.
+          - ``success``: the dry_run fields plus the five AWS-derived fields above.
+          - ``failed``: {error, duration, reason}.
+        """  # FIX: C6-RT-03 - document status-dependent report schema; dry-run omits AWS-derived fields by design
         logger.info(f"Blocking IP address: {ip_address}")  # FIX: C5-finding-3
         try:  # FIX: C5-finding-3
             cidr_block = str(ipaddress.ip_network(ip_address, strict=False))  # FIX: C5-finding-3

--- a/scripts/incident-response/auto-containment.py
+++ b/scripts/incident-response/auto-containment.py
@@ -275,6 +275,10 @@ class ContainmentManager:
         logger.info(f"Blocking IP address: {ip_address}")  # FIX: C5-finding-3
         try:  # FIX: C5-finding-3
             cidr_block = str(ipaddress.ip_network(ip_address, strict=False))  # FIX: C5-finding-3
+            if self.dry_run:  # FIX: C6-RT-03 - simulate BEFORE any AWS/NACL discovery so dry-run needs no credentials
+                logger.info("[DRY-RUN] Would add deny entries to the emergency network ACL")  # FIX: C6-RT-03
+                self.log_action("block_ip", ip_address, "dry_run", {"cidr_block": cidr_block, "duration": duration, "reason": reason})  # FIX: C6-RT-03 - log only locally-known fields; NACL id/rule numbers require AWS and are intentionally not resolved in dry-run
+                return True  # FIX: C6-RT-03
             network_acl_id = self._resolve_network_acl_id()  # FIX: C5-finding-3
             assert self.ec2 is not None  # pylance: _resolve_network_acl_id raises if self.ec2 is None
             allocation = self._allocate_acl_rule_numbers(network_acl_id, cidr_block)
@@ -282,10 +286,6 @@ class ContainmentManager:
             egress_rule_number = allocation["egress_rule_number"]
             ingress_already_present = allocation["ingress_already_present"]
             egress_already_present = allocation["egress_already_present"]
-            if self.dry_run:  # FIX: C5-finding-3
-                logger.info("[DRY-RUN] Would add deny entries to the emergency network ACL")  # FIX: C5-finding-3
-                self.log_action("block_ip", ip_address, "dry_run", {"cidr_block": cidr_block, "duration": duration, "reason": reason, "network_acl_id": network_acl_id, "ingress_rule_number": ingress_rule_number, "egress_rule_number": egress_rule_number, "ingress_already_present": ingress_already_present, "egress_already_present": egress_already_present})
-                return True  # FIX: C5-finding-3
             created_rule_numbers = []
             if not ingress_already_present:
                 self.ec2.create_network_acl_entry(NetworkAclId=network_acl_id, RuleNumber=ingress_rule_number, Protocol='-1', RuleAction='deny', Egress=False, CidrBlock=cidr_block)

--- a/tests/integration/test_playbook_procedures.py
+++ b/tests/integration/test_playbook_procedures.py
@@ -43,7 +43,7 @@ IMPACT_ANALYZER_PATH = Path(__file__).resolve().parents[2] / "scripts" / "incide
 def _load_auto_containment_module(tmp_path):  # FIX: C5-finding-3
     log_dir = tmp_path / "containment"  # FIX: C5-finding-3
     fake_ec2 = MagicMock()  # FIX: C5-finding-3
-    fake_ec2.describe_network_acls.return_value = {"NetworkAcls": [{"NetworkAclId": "acl-test-default", "Entries": []}]}  # FIX: C6-RT-03 - return a valid default NACL so the documented block_ip real-path command succeeds against the mock
+    fake_ec2.describe_network_acls.return_value = {"NetworkAcls": [{"NetworkAclId": "acl-test-default", "IsDefault": True, "VpcId": "vpc-test-0000", "OwnerId": "123456789012", "Associations": [{"NetworkAclAssociationId": "aclassoc-test-0000", "NetworkAclId": "acl-test-default", "SubnetId": "subnet-test-0000"}], "Entries": [], "Tags": []}]}  # FIX: C6-RT-03 - mirror the real boto3 default-NACL response shape (IsDefault/VpcId/Associations/OwnerId) so the mock matches what describe_network_acls actually returns; Entries kept empty so _allocate_acl_rule_numbers still picks deterministic rule numbers in the real-path block_ip test
     fake_iam = MagicMock()  # FIX: C5-finding-3
     fake_route53resolver = MagicMock()  # FIX: C5-finding-3
     fake_network = MagicMock()  # FIX: C5-finding-3
@@ -398,10 +398,14 @@ class TestAutoContainmentCliParity:
         )  # FIX: C6-RT-03
         assert rc == 0  # FIX: C6-RT-03 - dry-run rehearsal succeeds with no AWS credentials
         fake_ec2.describe_network_acls.assert_not_called()  # FIX: C6-RT-03 - proves no NACL discovery happened in dry-run
+        fake_ec2.create_network_acl_entry.assert_not_called()  # FIX: C6-RT-03 - the only other EC2 method block_ip's real path invokes; never reached in dry-run
+        assert fake_ec2.method_calls == []  # FIX: C6-RT-03 - comprehensive backstop: NO EC2 method of any kind runs in dry-run (subsumes replace_network_acl_entry and any future real-path call)
         report = _read_single_report(log_dir)  # FIX: C6-RT-03
-        assert report["actions_taken"][0]["action"] == "block_ip"  # FIX: C6-RT-03
-        assert report["actions_taken"][0]["status"] == "dry_run"  # FIX: C6-RT-03
-        assert report["actions_taken"][0]["dry_run"] is True  # FIX: C6-RT-03
+        actions = report["actions_taken"]  # FIX: C6-RT-03
+        assert len(actions) == 1  # FIX: C6-RT-03 - dry-run records exactly one action, so [0] is unambiguous (and proves no extra real-path action leaked in)
+        block_ip_action = next(a for a in actions if a["action"] == "block_ip")  # FIX: C6-RT-03 - select by action name, not position, so the assertions stay correct if recording order ever changes
+        assert block_ip_action["status"] == "dry_run"  # FIX: C6-RT-03
+        assert block_ip_action["dry_run"] is True  # FIX: C6-RT-03
 
 
 class TestForensicsCollectorRuntimeParity:

--- a/tests/integration/test_playbook_procedures.py
+++ b/tests/integration/test_playbook_procedures.py
@@ -43,6 +43,7 @@ IMPACT_ANALYZER_PATH = Path(__file__).resolve().parents[2] / "scripts" / "incide
 def _load_auto_containment_module(tmp_path):  # FIX: C5-finding-3
     log_dir = tmp_path / "containment"  # FIX: C5-finding-3
     fake_ec2 = MagicMock()  # FIX: C5-finding-3
+    fake_ec2.describe_network_acls.return_value = {"NetworkAcls": [{"NetworkAclId": "acl-test-default", "Entries": []}]}  # FIX: C6-RT-03 - return a valid default NACL so the documented block_ip real-path command succeeds against the mock
     fake_iam = MagicMock()  # FIX: C5-finding-3
     fake_route53resolver = MagicMock()  # FIX: C5-finding-3
     fake_network = MagicMock()  # FIX: C5-finding-3
@@ -385,6 +386,22 @@ class TestAutoContainmentCliParity:
             fake_docker_client.containers.get.assert_called_once_with("agent-prod-42")  # FIX: C5-finding-3
             fake_network.disconnect.assert_called()  # FIX: C5-finding-3
             fake_container.update.assert_called_once()  # FIX: C5-finding-3
+
+    def test_block_ip_dry_run_does_not_touch_aws(self, tmp_path):  # FIX: C6-RT-03
+        """block_ip --dry-run must simulate WITHOUT any AWS/NACL discovery (no credentials required)."""  # FIX: C6-RT-03
+        module, log_dir, fake_ec2, *_rest = _load_auto_containment_module(tmp_path)  # FIX: C6-RT-03
+        # Even if every EC2 call would fail (e.g. missing credentials), the dry-run must still succeed.  # FIX: C6-RT-03
+        fake_ec2.describe_network_acls.side_effect = Exception("Unable to locate credentials")  # FIX: C6-RT-03
+        rc = _run_auto_containment(  # FIX: C6-RT-03
+            module,  # FIX: C6-RT-03
+            ["--action", "block_ip", "--ip-address", "198.51.100.42", "--reason", "Rehearsal - IRP-002", "--dry-run"],  # FIX: C6-RT-03
+        )  # FIX: C6-RT-03
+        assert rc == 0  # FIX: C6-RT-03 - dry-run rehearsal succeeds with no AWS credentials
+        fake_ec2.describe_network_acls.assert_not_called()  # FIX: C6-RT-03 - proves no NACL discovery happened in dry-run
+        report = _read_single_report(log_dir)  # FIX: C6-RT-03
+        assert report["actions_taken"][0]["action"] == "block_ip"  # FIX: C6-RT-03
+        assert report["actions_taken"][0]["status"] == "dry_run"  # FIX: C6-RT-03
+        assert report["actions_taken"][0]["dry_run"] is True  # FIX: C6-RT-03
 
 
 class TestForensicsCollectorRuntimeParity:


### PR DESCRIPTION
block_ip_address() resolved the network ACL and allocated rule numbers (both call boto3 describe_network_acls) BEFORE checking self.dry_run, so a dry-run rehearsal failed with 'Unable to locate credentials'. The dry_run early-return now sits right after the local cidr_block validation, before any AWS call, mirroring isolate_container/update_rate_limits. The real (non-dry-run) path is unchanged and still fails closed without credentials. Also repairs the block_ip parity test's fake_ec2 mock (return a valid default NACL) so the documented real-path command succeeds under mock, and adds tests/integration test_block_ip_dry_run_does_not_touch_aws (asserts rc==0 + describe_network_acls.assert_not_called() with an injected credential-error side_effect). Evidence: dry-run no-creds -> exit 0 (no credential error); real no-creds -> exit 1 (fail-closed); tests/security 145 passed/2 skipped. Sibling C6-RT-04 (block_domain, same defect) intentionally not touched.