### PR TITLE
feat(C6-RT-05): add fail-closed identity-containment actions stubbed to the clawguard/shield contract

### DIFF
--- a/examples/incident-response/playbook-prompt-injection.md
+++ b/examples/incident-response/playbook-prompt-injection.md
@@ -315,9 +315,20 @@
 
 1. **Block the User/Agent**
    
+   > **⚠ Identity actions require an external integration and currently fail closed.**
+   > The `disable_account`, `revoke_all_sessions`, `enable_account`, and `permanent_ban`
+   > actions act on a user *identity* (e.g. `eve@external.com`), which has no AWS or local
+   > equivalent in this repo. They are valid `auto-containment.py` actions, but they
+   > **fail closed** — exiting non-zero with a `NotImplementedError` that documents the
+   > contract — until the `clawguard` policy authority (`CLAWGUARD_URL`/`CLAWGUARD_TOKEN`)
+   > and/or the `openclaw-shield` enforcement integration
+   > (`OPENCLAW_SHIELD_URL`/`OPENCLAW_SHIELD_TOKEN`) is wired. The network/agent actions
+   > (`block_ip`, `isolate_container`) below work as shown. Until the integration is
+   > configured, suspend/restore the identity out-of-band via your identity provider.
+
    **For Direct Injection** (malicious user):
    ```bash
-   # Suspend user account immediately
+   # Suspend user account immediately (identity action — fails closed until the integration is wired; see note above)
    ./scripts/incident-response/auto-containment.py \
      --action disable_account \
      --user-id eve@external.com \
@@ -708,7 +719,12 @@
    ```
 
 3. **Restore User Access** (if legitimate user was blocked)
-   
+
+   > **⚠** `enable_account` and `permanent_ban` are identity actions that **fail closed**
+   > (exit non-zero with a documented `NotImplementedError`) until the clawguard/openclaw-shield
+   > identity integration is wired — see the Phase 1 note. Until then, restore or ban the
+   > identity out-of-band via your identity provider.
+
    ```bash
    # Review block decision
    if [[ "$USER_WAS_MALICIOUS" == "false" ]]; then

--- a/examples/security-controls/input-validation.py
+++ b/examples/security-controls/input-validation.py
@@ -48,31 +48,47 @@ class PromptSanitizer:
     # phrases: 'reveal secrets' (14 bytes) encodes to 19 base64 chars).          # FIX: C5-7
     _B64_RE = re.compile(r"[A-Za-z0-9+/_-]{16,}={0,3}")  # FIX: C5-7
 
+    # Each entry is (human_readable_label, compiled_pattern). validate() surfaces the  # FIX: C6-RT-05
+    # LABEL in ValidationResult.reason, never the raw regex: a sanitizer that echoes its  # FIX: C6-RT-05
+    # exact detection pattern back to the (possibly hostile) submitter hands them the  # FIX: C6-RT-05
+    # evasion map. The regexes themselves are unchanged (no detection/evasion regression).  # FIX: C6-RT-05
     HIGH_RISK_PATTERNS = (  # FIX: C5-7
         # Char-insertion-aware + synonym-aware "ignore all previous instructions"
-        re.compile(  # FIX: C5-7
-            r"(?:i[^a-zA-Z0-9]{0,3}g[^a-zA-Z0-9]{0,3}n[^a-zA-Z0-9]{0,3}o[^a-zA-Z0-9]{0,3}"
-            r"r[^a-zA-Z0-9]{0,3}e"
-            r"|disregard|forget|overlook|bypass)"
-            r"\s+(?:all\s+)?(?:previous|prior|earlier|past|above|original)\s+"
-            r"(?:instructions?|directives?|commands?|rules?|prompts?|context|training)",
-            re.IGNORECASE,
-        ),  # FIX: C5-7
+        (
+            "instruction override (e.g. 'ignore all previous instructions')",  # FIX: C6-RT-05
+            re.compile(  # FIX: C5-7
+                r"(?:i[^a-zA-Z0-9]{0,3}g[^a-zA-Z0-9]{0,3}n[^a-zA-Z0-9]{0,3}o[^a-zA-Z0-9]{0,3}"
+                r"r[^a-zA-Z0-9]{0,3}e"
+                r"|disregard|forget|overlook|bypass)"
+                r"\s+(?:all\s+)?(?:previous|prior|earlier|past|above|original)\s+"
+                r"(?:instructions?|directives?|commands?|rules?|prompts?|context|training)",
+                re.IGNORECASE,
+            ),
+        ),  # FIX: C6-RT-05
         # "system prompt" flagged only in suspicious access/override context  # FIX: C5-7
-        re.compile(  # FIX: C5-7
-            r"(?:(?:reveal|expose|leak|bypass|override|modify|ignore|extract|show|print)"
-            r"\s+(?:(?:me\s+)?(?:the|your|my|all)\s+)?system\s+prompt"
-            r"|system\s+prompt\s*[:=]\s*)",
-            re.IGNORECASE,
-        ),  # FIX: C5-7
+        (
+            "system prompt access/override",  # FIX: C6-RT-05
+            re.compile(  # FIX: C5-7
+                r"(?:(?:reveal|expose|leak|bypass|override|modify|ignore|extract|show|print)"
+                r"\s+(?:(?:me\s+)?(?:the|your|my|all)\s+)?system\s+prompt"
+                r"|system\s+prompt\s*[:=]\s*)",
+                re.IGNORECASE,
+            ),
+        ),  # FIX: C6-RT-05
         # "developer message" flagged only when accessed/exposed in attack context  # FIX: C5-7
-        re.compile(  # FIX: C5-7
-            r"(?:(?:reveal|expose|leak|bypass|override|modify|ignore|extract|show|print)"
-            r"\s+(?:(?:me\s+)?(?:the|your|my|all)\s+)?developer\s+message"
-            r"|developer\s+message\s*[:=]\s*)",
-            re.IGNORECASE,
-        ),  # FIX: C5-7
-        re.compile(r"reveal\s+secrets?", re.IGNORECASE),
+        (
+            "developer message access/override",  # FIX: C6-RT-05
+            re.compile(  # FIX: C5-7
+                r"(?:(?:reveal|expose|leak|bypass|override|modify|ignore|extract|show|print)"
+                r"\s+(?:(?:me\s+)?(?:the|your|my|all)\s+)?developer\s+message"
+                r"|developer\s+message\s*[:=]\s*)",
+                re.IGNORECASE,
+            ),
+        ),  # FIX: C6-RT-05
+        (
+            "reveal secrets",  # FIX: C6-RT-05
+            re.compile(r"reveal\s+secrets?", re.IGNORECASE),
+        ),  # FIX: C6-RT-05
     )  # FIX: C5-7
 
     @classmethod
@@ -94,9 +110,9 @@ class PromptSanitizer:
         normalized = self._normalize(prompt)  # FIX: C5-7
 
         # Direct match on normalised text (handles homoglyphs + char-insertion)
-        for pattern in self.HIGH_RISK_PATTERNS:  # FIX: C5-7
+        for label, pattern in self.HIGH_RISK_PATTERNS:  # FIX: C5-7  # FIX: C6-RT-05 - unpack (label, pattern)
             if pattern.search(normalized):  # FIX: C5-7
-                return ValidationResult(False, 0.95, f"Matched risky pattern: {pattern.pattern}")
+                return ValidationResult(False, 0.95, f"Matched risky pattern: {label}")  # FIX: C6-RT-05 - surface the label, not the raw regex (no detection-internals leak)
 
         # Base64 blob detection: decode each candidate and re-check           # FIX: C5-7
         for match in self._B64_RE.finditer(normalized):  # FIX: C5-7
@@ -107,10 +123,10 @@ class PromptSanitizer:
                     "utf-8", errors="replace"
                 )  # FIX: C5-7
                 decoded_norm = self._normalize(decoded)  # FIX: C5-7
-                for pattern in self.HIGH_RISK_PATTERNS:  # FIX: C5-7
+                for label, pattern in self.HIGH_RISK_PATTERNS:  # FIX: C5-7  # FIX: C6-RT-05 - unpack (label, pattern)
                     if pattern.search(decoded_norm):  # FIX: C5-7
                         return ValidationResult(  # FIX: C5-7
-                            False, 0.95, "Matched risky pattern in base64 decoded content"  # FIX: C5-7
+                            False, 0.95, f"Matched risky pattern in base64 decoded content: {label}"  # FIX: C5-7  # FIX: C6-RT-05 - include label, not the raw regex
                         )  # FIX: C5-7
             except (ValueError, UnicodeDecodeError):  # FIX: C5-7 — narrow: programming errors propagate
                 pass  # malformed base64 or non-UTF-8 payload — skip this blob  # FIX: C5-7

--- a/scripts/incident-response/auto-containment.py
+++ b/scripts/incident-response/auto-containment.py
@@ -39,6 +39,7 @@ Related: playbook-prompt-injection.md, IRP-001.md
 """
 
 import argparse
+import hashlib  # FIX: C6-RT-05 - redact identity PII from operational logs
 import ipaddress  # FIX: C5-finding-3
 import json
 import logging
@@ -85,6 +86,54 @@ logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+
+# --action accepts a single canonical kebab-case spelling per action. snake_case  # FIX: C6-RT-05
+# spellings (e.g. block_ip, disable_account) are accepted as backward-compatible  # FIX: C6-RT-05
+# aliases so existing runbooks/automation keep working; every value is normalized  # FIX: C6-RT-05
+# to its canonical kebab-case form before dispatch. NOTE: CLI surface only -- the  # FIX: C6-RT-05
+# internal log_action() names stay snake_case (the audit-log schema is unchanged).  # FIX: C6-RT-05
+CANONICAL_ACTIONS = [  # FIX: C6-RT-05
+    "isolate-ec2",  # FIX: C6-RT-05
+    "revoke-credentials",  # FIX: C6-RT-05
+    "isolate-docker",  # FIX: C6-RT-05
+    "block-ip",  # FIX: C6-RT-05
+    "block-domain",  # FIX: C6-RT-05
+    "isolate-container",  # FIX: C6-RT-05
+    "update-rate-limits",  # FIX: C6-RT-05
+    "disable-account",  # FIX: C6-RT-05
+    "revoke-all-sessions",  # FIX: C6-RT-05
+    "enable-account",  # FIX: C6-RT-05
+    "permanent-ban",  # FIX: C6-RT-05
+    "kill-skill",  # FIX: C6-RT-05 - skill-enforcement action (fail-closed stub)
+]  # FIX: C6-RT-05
+
+
+def _normalize_action(value: str) -> str:  # FIX: C6-RT-05
+    """Normalize an --action value to its canonical kebab-case form.
+
+    Lowercases and maps '_' -> '-' so snake_case aliases (block_ip,
+    disable_account, ...) resolve to the canonical kebab-case action. Validation
+    against CANONICAL_ACTIONS is left to argparse `choices`, which produces the
+    standard "invalid choice" error listing the canonical names.
+    """  # FIX: C6-RT-05
+    return value.strip().lower().replace("_", "-")  # FIX: C6-RT-05
+
+
+def _redact_identity(user_id: str) -> str:  # FIX: C6-RT-05
+    """Return a stable, non-PII token for a user identity, safe for operational logs.
+
+    Identity-containment targets are typically emails/usernames (PII). Operational
+    logs (INFO/ERROR) can be shipped to CI output or centralized log aggregators
+    whose access is broader than the deliberate containment audit trail, so the raw
+    identity is never emitted there -- only a stable SHA-256-derived token that lets
+    an operator correlate log lines for the same identity. The full identity is still
+    recorded in the access-controlled containment audit log (log_action target) for
+    incident-response forensics. This is log-hygiene redaction, not cryptographic
+    anonymization (the unsalted digest is kept stable so log lines stay correlatable).
+    """  # FIX: C6-RT-05
+    digest = hashlib.sha256(user_id.encode("utf-8")).hexdigest()[:12]  # FIX: C6-RT-05
+    return f"identity:{digest}"  # FIX: C6-RT-05
 
 
 class ContainmentManager:
@@ -336,13 +385,16 @@ class ContainmentManager:
           - clawguard (policy):        POST {policy, subject: {user_id}} -> {allowed: bool, reason: str}  [CLAWGUARD_URL, CLAWGUARD_TOKEN]
           - openclaw-shield (enforce): POST {action, target: {user_id}} -> {applied: bool}               [OPENCLAW_SHIELD_URL, OPENCLAW_SHIELD_TOKEN]
         """  # FIX: C6-RT-05
-        logger.info(f"{action} requested for identity {user_id} (details={details})")  # FIX: C6-RT-05
+        # PII hygiene: log only a redacted identity token and never the arbitrary  # FIX: C6-RT-05
+        # `details` kwargs on this operational INFO line -- it can reach CI/centralized  # FIX: C6-RT-05
+        # logs. The full identity + reason are retained in the audit trail (log_action).  # FIX: C6-RT-05
+        logger.info(f"{action} requested for {_redact_identity(user_id)}")  # FIX: C6-RT-05
         raise NotImplementedError(  # FIX: C6-RT-05
             f"{action} is not wired: acting on a user identity requires the clawguard policy authority "
             f"(CLAWGUARD_URL/CLAWGUARD_TOKEN; POST {{policy, subject}} -> {{allowed, reason}}) and/or the "
             f"openclaw-shield enforcement integration (OPENCLAW_SHIELD_URL/OPENCLAW_SHIELD_TOKEN; "
             f"POST {{action, target}} -> {{applied}}). No automated identity action exists in this repo "
-            f"yet; refusing to report a false containment for {user_id}."  # FIX: C6-RT-05
+            f"yet; refusing to report a false containment for {_redact_identity(user_id)}."  # FIX: C6-RT-05 - redact PII; this message propagates to the operational error log
         )  # FIX: C6-RT-05
 
     def disable_account(self, user_id: str, duration: Optional[str] = None, reason: Optional[str] = None) -> bool:  # FIX: C6-RT-05
@@ -360,6 +412,27 @@ class ContainmentManager:
     def permanent_ban(self, user_id: str, reason: Optional[str] = None) -> bool:  # FIX: C6-RT-05
         """Permanently ban a user identity (fail-closed stub until wired)."""  # FIX: C6-RT-05
         return self._identity_action_stub("permanent_ban", user_id, reason=reason)  # FIX: C6-RT-05
+
+    def kill_skill(self, agent_id: str, skill_name: Optional[str] = None, reason: Optional[str] = None) -> bool:  # FIX: C6-RT-05
+        """Terminate a malicious skill on a specific agent (fail-closed stub until wired).
+
+        Killing a skill process on a remote agent is an enforcement action with no AWS or
+        local-Docker equivalent in this script (the skill-compromise playbook documents a
+        manual `docker exec <agent> pkill` fallback for that). It depends on the openclaw-shield
+        enforcement integration / agent control-plane, which is NOT wired here. Per the
+        unwired-integration rule it raises NotImplementedError so callers FAIL CLOSED rather
+        than report a false containment, and never silently no-ops. To wire it:
+          - openclaw-shield (enforce): POST {action: 'kill_skill', target: {agent_id, skill_name}} -> {applied: bool}  [OPENCLAW_SHIELD_URL, OPENCLAW_SHIELD_TOKEN]
+        agent_id/skill_name are operational identifiers (not PII), so they are logged as-is.
+        """  # FIX: C6-RT-05
+        logger.info(f"kill_skill requested for skill {skill_name!r} on agent {agent_id}")  # FIX: C6-RT-05
+        raise NotImplementedError(  # FIX: C6-RT-05
+            f"kill_skill is not wired: terminating skill {skill_name!r} on agent {agent_id} requires the "
+            f"openclaw-shield enforcement integration (OPENCLAW_SHIELD_URL/OPENCLAW_SHIELD_TOKEN; "
+            f"POST {{action, target}} -> {{applied}}). No automated skill-kill action exists in this repo "
+            f"yet; refusing to report a false containment. Use the documented 'docker exec <agent> pkill' "
+            f"fallback for manual termination."  # FIX: C6-RT-05
+        )  # FIX: C6-RT-05
 
     def _write_quarantine_manifest(  # FIX: C6-H-07
         self,  # FIX: C6-H-07
@@ -850,13 +923,21 @@ Examples:
     python3 auto-containment.py --incident INC-2024-001 \\
         --domain attacker.example.com --reason "C2 domain" --action block_domain
 
-    # Isolate a named container (network disconnect + quarantine label)
+    # Isolate a named container (network disconnect + quarantine manifest)
     python3 auto-containment.py --incident INC-2024-001 \\
-        --container-id agent-prod-42 --action isolate_container
+        --container-id agent-prod-42 --action isolate-container
 
     # Apply aggressive rate-limit override profile
     python3 auto-containment.py --incident INC-2024-001 \\
-        --mode aggressive --limits '{\"per_ip_per_minute\":10}' --action update_rate_limits
+        --mode aggressive --limits '{\"per_ip_per_minute\":10}' --action update-rate-limits
+
+    # Disable a compromised user identity (fail-closed stub until the identity integration is wired)
+    python3 auto-containment.py --incident INC-2024-001 \\
+        --user-id eve@external.com --reason "Prompt injection" --action disable-account
+
+    # Kill a malicious skill on an agent (fail-closed stub until the skill-enforcement integration is wired)
+    python3 auto-containment.py --incident INC-2024-001 \\
+        --agent-id agent-prod-12 --skill-name "@attacker/credential-stealer" --action kill-skill
 
     # Dry-run any action
     python3 auto-containment.py --incident INC-2024-001 \\
@@ -869,14 +950,24 @@ Environment Variables:
     DNS_FIREWALL_DOMAIN_LIST_ID Route53 Resolver domain list for domain blocking; created if absent
     RATE_LIMIT_CONFIG_PATH      File path for rate-limit override profile
 
-Actions (all implemented):
+Actions (kebab-case canonical; snake_case spellings accepted as aliases):
     isolate-ec2           Snapshot volumes + apply quarantine SG  # FIX: C5-Batch-G
     revoke-credentials    Deactivate IAM access keys + attach deny-all policy  # FIX: C5-Batch-G
     isolate-docker        Disconnect Docker container from all networks  # FIX: C5-Batch-G
-    block_ip              Add deny entries to emergency network ACL  # FIX: C5-Batch-G
-    block_domain          Add domain to Route53 Resolver DNS firewall list  # FIX: C5-Batch-G
-    isolate_container     Network disconnect + quarantine label (Docker)  # FIX: C5-Batch-G
-    update_rate_limits    Write emergency rate-limit override profile  # FIX: C5-Batch-G
+    block-ip              Add deny entries to emergency network ACL  # FIX: C6-RT-05
+    block-domain          Add domain to Route53 Resolver DNS firewall list  # FIX: C6-RT-05
+    isolate-container     Network disconnect + quarantine manifest (Docker)  # FIX: C6-RT-05
+    update-rate-limits    Write emergency rate-limit override profile  # FIX: C6-RT-05
+    disable-account       Disable a user identity (fail-closed stub until wired)  # FIX: C6-RT-05
+    revoke-all-sessions   Revoke all active sessions for a user (fail-closed stub)  # FIX: C6-RT-05
+    enable-account        Re-enable a user identity (fail-closed stub until wired)  # FIX: C6-RT-05
+    permanent-ban         Permanently ban a user identity (fail-closed stub)  # FIX: C6-RT-05
+    kill-skill            Terminate a malicious skill on an agent (fail-closed stub)  # FIX: C6-RT-05
+
+Accepted aliases (snake_case, normalized to the kebab-case names above):  # FIX: C6-RT-05
+    block_ip, block_domain, isolate_container, update_rate_limits,  # FIX: C6-RT-05
+    disable_account, revoke_all_sessions, enable_account, permanent_ban,  # FIX: C6-RT-05
+    isolate_ec2, revoke_credentials, isolate_docker, kill_skill  # FIX: C6-RT-05
         """  # FIX: C5-Batch-G
     )
     
@@ -893,16 +984,19 @@ Actions (all implemented):
     parser.add_argument(
         "--action",
         required=True,
-        choices=["isolate-ec2", "revoke-credentials", "isolate-docker", "block_ip", "block_domain", "isolate_container", "update_rate_limits", "disable_account", "revoke_all_sessions", "enable_account", "permanent_ban"],  # FIX: C5-finding-3  # FIX: C6-RT-05 - identity-containment actions (fail-closed stubs)
-        help="Containment action to perform"
+        type=_normalize_action,  # FIX: C6-RT-05 - normalize snake_case aliases (block_ip, disable_account, ...) to canonical kebab-case before validation
+        choices=CANONICAL_ACTIONS,  # FIX: C5-finding-3  # FIX: C6-RT-05 - canonical kebab-case names; snake_case spellings accepted via type= normalization
+        help="Containment action to perform (kebab-case canonical; snake_case spellings accepted as aliases)"  # FIX: C6-RT-05
     )
     parser.add_argument("--ip-address", help="IP address to block with the block_ip action")  # FIX: C5-finding-3
     parser.add_argument("--domain", help="Domain to block with the block_domain action")  # FIX: C5-finding-3
     parser.add_argument("--container-id", help="Container ID to isolate with the isolate_container action")  # FIX: C5-finding-3
     parser.add_argument("--duration", help="Duration for temporary containment actions")  # FIX: C5-finding-3
     parser.add_argument("--reason", help="Reason recorded in the containment log")  # FIX: C5-finding-3
-    parser.add_argument("--user-id", help="User identity (e.g. user@example.com) for identity-containment actions: disable_account/revoke_all_sessions/enable_account/permanent_ban")  # FIX: C6-RT-05
-    parser.add_argument("--send-warning-email", action="store_true", help="With enable_account, request a warning email on restoration (applied by the identity integration when wired)")  # FIX: C6-RT-05
+    parser.add_argument("--user-id", help="User identity (e.g. user@example.com) for identity-containment actions: disable-account/revoke-all-sessions/enable-account/permanent-ban")  # FIX: C6-RT-05
+    parser.add_argument("--send-warning-email", action="store_true", help="With enable-account, request a warning email on restoration (applied by the identity integration when wired)")  # FIX: C6-RT-05
+    parser.add_argument("--agent-id", help="Agent identifier (e.g. agent-prod-12) for the kill-skill action")  # FIX: C6-RT-05
+    parser.add_argument("--skill-name", help="Skill name to terminate with the kill-skill action (e.g. @vendor/skill)")  # FIX: C6-RT-05
     parser.add_argument("--mode", choices=["normal", "aggressive", "emergency"], help="Rate-limit mode to apply with update_rate_limits")  # FIX: C5-finding-3
     parser.add_argument("--limits", help="JSON object describing rate-limit overrides for update_rate_limits")  # FIX: C5-finding-3
     parser.add_argument(
@@ -948,47 +1042,68 @@ Actions (all implemented):
         container_id = raw_container_target.split(":", 1)[1] if raw_container_target and ":" in raw_container_target else raw_container_target  # FIX: C5-finding-3
         success = manager.isolate_docker_container(container_id)
 
-    elif args.action == "block_ip":  # FIX: C5-finding-3
+    elif args.action == "block-ip":  # FIX: C5-finding-3  # FIX: C6-RT-05 - canonical kebab (block_ip alias normalized here)
         ip_address = args.ip_address or args.target  # FIX: C5-finding-3
         if not ip_address:  # FIX: C5-finding-3
-            parser.error("--ip-address or --target is required for block_ip")  # FIX: C5-finding-3
+            parser.error("--ip-address or --target is required for block-ip")  # FIX: C5-finding-3  # FIX: C6-RT-05
         success = manager.block_ip_address(ip_address, duration=args.duration, reason=args.reason)  # FIX: C5-finding-3
 
-    elif args.action == "block_domain":  # FIX: C5-finding-3
+    elif args.action == "block-domain":  # FIX: C5-finding-3  # FIX: C6-RT-05 - canonical kebab (block_domain alias normalized here)
         domain = args.domain or args.target  # FIX: C5-finding-3
         if not domain:  # FIX: C5-finding-3
-            parser.error("--domain or --target is required for block_domain")  # FIX: C5-finding-3
+            parser.error("--domain or --target is required for block-domain")  # FIX: C5-finding-3  # FIX: C6-RT-05
         success = manager.block_domain_name(domain, duration=args.duration, reason=args.reason)  # FIX: C5-finding-3
 
-    elif args.action == "isolate_container":  # FIX: C5-finding-3
+    elif args.action == "isolate-container":  # FIX: C5-finding-3  # FIX: C6-RT-05 - canonical kebab (isolate_container alias normalized here)
         raw_container_target = args.container_id or args.target  # FIX: C5-finding-3
         if not raw_container_target:  # FIX: C5-finding-3
-            parser.error("--container-id or --target is required for isolate_container")  # FIX: C5-finding-3
+            parser.error("--container-id or --target is required for isolate-container")  # FIX: C5-finding-3  # FIX: C6-RT-05
         container_id = raw_container_target.split(":", 1)[1] if ":" in raw_container_target else raw_container_target  # FIX: C5-finding-3
         success = manager.isolate_container(container_id, reason=args.reason)  # FIX: C5-finding-3
 
-    elif args.action == "update_rate_limits":  # FIX: C5-finding-3
+    elif args.action == "update-rate-limits":  # FIX: C5-finding-3  # FIX: C6-RT-05 - canonical kebab (update_rate_limits alias normalized here)
         if not args.mode:  # FIX: C5-finding-3
-            parser.error("--mode is required for update_rate_limits")  # FIX: C5-finding-3
+            parser.error("--mode is required for update-rate-limits")  # FIX: C5-finding-3  # FIX: C6-RT-05
         if parsed_limits is None:  # FIX: C5-finding-3
-            parser.error("--limits is required for update_rate_limits")  # FIX: C5-finding-3
+            parser.error("--limits is required for update-rate-limits")  # FIX: C5-finding-3  # FIX: C6-RT-05
         success = manager.update_rate_limits(args.mode, parsed_limits, reason=args.reason)  # FIX: C5-finding-3
 
-    elif args.action in ("disable_account", "revoke_all_sessions", "enable_account", "permanent_ban"):  # FIX: C6-RT-05 - identity-containment actions
+    elif args.action in ("disable-account", "revoke-all-sessions", "enable-account", "permanent-ban"):  # FIX: C6-RT-05 - identity-containment actions (canonical kebab; snake_case aliases normalized here)
         if not args.user_id:  # FIX: C6-RT-05
             parser.error(f"--user-id is required for {args.action}")  # FIX: C6-RT-05
+        # Audit-log under the snake_case action name so identity events match the  # FIX: C6-RT-05
+        # log_action() schema every other action uses (block_ip, isolate_ec2, ...).  # FIX: C6-RT-05
+        identity_log_action = args.action.replace("-", "_")  # FIX: C6-RT-05
+        # Capture the action-specific inputs that were attempted so the audit report records  # FIX: C6-RT-05
+        # WHAT was requested even when the integration is unwired (fail-closed). These are  # FIX: C6-RT-05
+        # operator-supplied, non-PII request params; the identity itself stays in `target`.  # FIX: C6-RT-05
+        requested_params: Dict[str, Any] = {"reason": args.reason}  # FIX: C6-RT-05
+        if args.action == "disable-account":  # FIX: C6-RT-05
+            requested_params["duration"] = args.duration  # FIX: C6-RT-05
+        elif args.action == "enable-account":  # FIX: C6-RT-05
+            requested_params["send_warning_email"] = args.send_warning_email  # FIX: C6-RT-05
         try:  # FIX: C6-RT-05 - the identity integration is unwired and raises NotImplementedError; handle it explicitly
-            if args.action == "disable_account":  # FIX: C6-RT-05
+            if args.action == "disable-account":  # FIX: C6-RT-05
                 success = manager.disable_account(args.user_id, duration=args.duration, reason=args.reason)  # FIX: C6-RT-05
-            elif args.action == "revoke_all_sessions":  # FIX: C6-RT-05
+            elif args.action == "revoke-all-sessions":  # FIX: C6-RT-05
                 success = manager.revoke_all_sessions(args.user_id, reason=args.reason)  # FIX: C6-RT-05
-            elif args.action == "enable_account":  # FIX: C6-RT-05
+            elif args.action == "enable-account":  # FIX: C6-RT-05
                 success = manager.enable_account(args.user_id, send_warning_email=args.send_warning_email, reason=args.reason)  # FIX: C6-RT-05
-            else:  # permanent_ban  # FIX: C6-RT-05
+            else:  # permanent-ban  # FIX: C6-RT-05
                 success = manager.permanent_ban(args.user_id, reason=args.reason)  # FIX: C6-RT-05
         except NotImplementedError as e:  # FIX: C6-RT-05 - fail closed: log as failed, never fake success or crash with a traceback
             logger.error(f"✗ {args.action} unavailable: {e}")  # FIX: C6-RT-05
-            manager.log_action(args.action, args.user_id, "failed", {"error": str(e), "reason": args.reason})  # FIX: C6-RT-05
+            manager.log_action(identity_log_action, args.user_id, "failed", {"error": str(e), **requested_params})  # FIX: C6-RT-05 - include attempted params (duration/send_warning_email) for forensics
+            success = False  # FIX: C6-RT-05
+
+    elif args.action == "kill-skill":  # FIX: C6-RT-05 - skill-enforcement action (canonical kebab; kill_skill alias normalized here)
+        if not args.agent_id:  # FIX: C6-RT-05
+            parser.error("--agent-id is required for kill-skill")  # FIX: C6-RT-05
+        try:  # FIX: C6-RT-05 - the skill-enforcement integration is unwired and raises NotImplementedError; handle it explicitly
+            success = manager.kill_skill(args.agent_id, skill_name=args.skill_name, reason=args.reason)  # FIX: C6-RT-05
+        except NotImplementedError as e:  # FIX: C6-RT-05 - fail closed: log as failed, never fake success or crash with a traceback
+            logger.error(f"✗ kill-skill unavailable: {e}")  # FIX: C6-RT-05
+            manager.log_action("kill_skill", args.agent_id, "failed", {"error": str(e), "skill_name": args.skill_name, "reason": args.reason})  # FIX: C6-RT-05
             success = False  # FIX: C6-RT-05
 
     # Save report

--- a/scripts/incident-response/auto-containment.py
+++ b/scripts/incident-response/auto-containment.py
@@ -326,6 +326,41 @@ class ContainmentManager:
             self.log_action("block_domain", domain, "failed", {"error": str(e), "duration": duration, "reason": reason})  # FIX: C5-finding-3
             return False  # FIX: C5-finding-3
 
+    def _identity_action_stub(self, action: str, user_id: str, **details: Any) -> bool:  # FIX: C6-RT-05
+        """Fail-closed stub for identity-containment actions (disable/enable/ban/revoke-sessions).
+
+        Acting on a user identity (e.g. eve@external.com) is a policy/enforcement action with no
+        AWS or local equivalent in this repo; it depends on an external identity integration that
+        is NOT wired here. Per the unwired-integration rule it raises NotImplementedError so callers
+        FAIL CLOSED rather than report a false containment, and never silently no-ops. To wire it:
+          - clawguard (policy):        POST {policy, subject: {user_id}} -> {allowed: bool, reason: str}  [CLAWGUARD_URL, CLAWGUARD_TOKEN]
+          - openclaw-shield (enforce): POST {action, target: {user_id}} -> {applied: bool}               [OPENCLAW_SHIELD_URL, OPENCLAW_SHIELD_TOKEN]
+        """  # FIX: C6-RT-05
+        logger.info(f"{action} requested for identity {user_id} (details={details})")  # FIX: C6-RT-05
+        raise NotImplementedError(  # FIX: C6-RT-05
+            f"{action} is not wired: acting on a user identity requires the clawguard policy authority "
+            f"(CLAWGUARD_URL/CLAWGUARD_TOKEN; POST {{policy, subject}} -> {{allowed, reason}}) and/or the "
+            f"openclaw-shield enforcement integration (OPENCLAW_SHIELD_URL/OPENCLAW_SHIELD_TOKEN; "
+            f"POST {{action, target}} -> {{applied}}). No automated identity action exists in this repo "
+            f"yet; refusing to report a false containment for {user_id}."  # FIX: C6-RT-05
+        )  # FIX: C6-RT-05
+
+    def disable_account(self, user_id: str, duration: Optional[str] = None, reason: Optional[str] = None) -> bool:  # FIX: C6-RT-05
+        """Disable a user identity (fail-closed stub until the identity integration is wired)."""  # FIX: C6-RT-05
+        return self._identity_action_stub("disable_account", user_id, duration=duration, reason=reason)  # FIX: C6-RT-05
+
+    def revoke_all_sessions(self, user_id: str, reason: Optional[str] = None) -> bool:  # FIX: C6-RT-05
+        """Revoke all active sessions for a user identity (fail-closed stub until wired)."""  # FIX: C6-RT-05
+        return self._identity_action_stub("revoke_all_sessions", user_id, reason=reason)  # FIX: C6-RT-05
+
+    def enable_account(self, user_id: str, send_warning_email: bool = False, reason: Optional[str] = None) -> bool:  # FIX: C6-RT-05
+        """Re-enable a previously disabled user identity (fail-closed stub until wired)."""  # FIX: C6-RT-05
+        return self._identity_action_stub("enable_account", user_id, send_warning_email=send_warning_email, reason=reason)  # FIX: C6-RT-05
+
+    def permanent_ban(self, user_id: str, reason: Optional[str] = None) -> bool:  # FIX: C6-RT-05
+        """Permanently ban a user identity (fail-closed stub until wired)."""  # FIX: C6-RT-05
+        return self._identity_action_stub("permanent_ban", user_id, reason=reason)  # FIX: C6-RT-05
+
     def _write_quarantine_manifest(  # FIX: C6-H-07
         self,  # FIX: C6-H-07
         incident_id: str,  # FIX: C6-H-07
@@ -858,7 +893,7 @@ Actions (all implemented):
     parser.add_argument(
         "--action",
         required=True,
-        choices=["isolate-ec2", "revoke-credentials", "isolate-docker", "block_ip", "block_domain", "isolate_container", "update_rate_limits"],  # FIX: C5-finding-3
+        choices=["isolate-ec2", "revoke-credentials", "isolate-docker", "block_ip", "block_domain", "isolate_container", "update_rate_limits", "disable_account", "revoke_all_sessions", "enable_account", "permanent_ban"],  # FIX: C5-finding-3  # FIX: C6-RT-05 - identity-containment actions (fail-closed stubs)
         help="Containment action to perform"
     )
     parser.add_argument("--ip-address", help="IP address to block with the block_ip action")  # FIX: C5-finding-3
@@ -866,6 +901,8 @@ Actions (all implemented):
     parser.add_argument("--container-id", help="Container ID to isolate with the isolate_container action")  # FIX: C5-finding-3
     parser.add_argument("--duration", help="Duration for temporary containment actions")  # FIX: C5-finding-3
     parser.add_argument("--reason", help="Reason recorded in the containment log")  # FIX: C5-finding-3
+    parser.add_argument("--user-id", help="User identity (e.g. user@example.com) for identity-containment actions: disable_account/revoke_all_sessions/enable_account/permanent_ban")  # FIX: C6-RT-05
+    parser.add_argument("--send-warning-email", action="store_true", help="With enable_account, request a warning email on restoration (applied by the identity integration when wired)")  # FIX: C6-RT-05
     parser.add_argument("--mode", choices=["normal", "aggressive", "emergency"], help="Rate-limit mode to apply with update_rate_limits")  # FIX: C5-finding-3
     parser.add_argument("--limits", help="JSON object describing rate-limit overrides for update_rate_limits")  # FIX: C5-finding-3
     parser.add_argument(
@@ -936,7 +973,24 @@ Actions (all implemented):
         if parsed_limits is None:  # FIX: C5-finding-3
             parser.error("--limits is required for update_rate_limits")  # FIX: C5-finding-3
         success = manager.update_rate_limits(args.mode, parsed_limits, reason=args.reason)  # FIX: C5-finding-3
-    
+
+    elif args.action in ("disable_account", "revoke_all_sessions", "enable_account", "permanent_ban"):  # FIX: C6-RT-05 - identity-containment actions
+        if not args.user_id:  # FIX: C6-RT-05
+            parser.error(f"--user-id is required for {args.action}")  # FIX: C6-RT-05
+        try:  # FIX: C6-RT-05 - the identity integration is unwired and raises NotImplementedError; handle it explicitly
+            if args.action == "disable_account":  # FIX: C6-RT-05
+                success = manager.disable_account(args.user_id, duration=args.duration, reason=args.reason)  # FIX: C6-RT-05
+            elif args.action == "revoke_all_sessions":  # FIX: C6-RT-05
+                success = manager.revoke_all_sessions(args.user_id, reason=args.reason)  # FIX: C6-RT-05
+            elif args.action == "enable_account":  # FIX: C6-RT-05
+                success = manager.enable_account(args.user_id, send_warning_email=args.send_warning_email, reason=args.reason)  # FIX: C6-RT-05
+            else:  # permanent_ban  # FIX: C6-RT-05
+                success = manager.permanent_ban(args.user_id, reason=args.reason)  # FIX: C6-RT-05
+        except NotImplementedError as e:  # FIX: C6-RT-05 - fail closed: log as failed, never fake success or crash with a traceback
+            logger.error(f"✗ {args.action} unavailable: {e}")  # FIX: C6-RT-05
+            manager.log_action(args.action, args.user_id, "failed", {"error": str(e), "reason": args.reason})  # FIX: C6-RT-05
+            success = False  # FIX: C6-RT-05
+
     # Save report
     manager.save_containment_report()
     

--- a/tests/integration/test_playbook_procedures.py
+++ b/tests/integration/test_playbook_procedures.py
@@ -333,6 +333,10 @@ class TestAutoContainmentCliParity:
         assert "block_domain" in help_output  # FIX: C5-finding-3
         assert "isolate_container" in help_output  # FIX: C5-finding-3
         assert "update_rate_limits" in help_output  # FIX: C5-finding-3
+        assert "disable_account" in help_output  # FIX: C6-RT-05
+        assert "revoke_all_sessions" in help_output  # FIX: C6-RT-05
+        assert "enable_account" in help_output  # FIX: C6-RT-05
+        assert "permanent_ban" in help_output  # FIX: C6-RT-05
 
     @pytest.mark.parametrize(  # FIX: C5-finding-3
         ("args", "expected_action", "expected_target", "expected_reason", "expected_mode"),  # FIX: C5-finding-3
@@ -385,6 +389,27 @@ class TestAutoContainmentCliParity:
             fake_docker_client.containers.get.assert_called_once_with("agent-prod-42")  # FIX: C5-finding-3
             fake_network.disconnect.assert_called()  # FIX: C5-finding-3
             fake_container.update.assert_called_once()  # FIX: C5-finding-3
+
+    @pytest.mark.parametrize(  # FIX: C6-RT-05
+        ("action", "extra_args"),  # FIX: C6-RT-05
+        [  # FIX: C6-RT-05
+            ("disable_account", ["--user-id", "eve@external.com", "--duration", "24h"]),  # FIX: C6-RT-05
+            ("revoke_all_sessions", ["--user-id", "eve@external.com"]),  # FIX: C6-RT-05
+            ("enable_account", ["--user-id", "user@openclaw.ai", "--send-warning-email"]),  # FIX: C6-RT-05
+            ("permanent_ban", ["--user-id", "eve@external.com"]),  # FIX: C6-RT-05
+        ],  # FIX: C6-RT-05
+        ids=["disable_account", "revoke_all_sessions", "enable_account", "permanent_ban"],  # FIX: C6-RT-05
+    )  # FIX: C6-RT-05
+    def test_identity_actions_are_accepted_but_fail_closed(self, tmp_path, action, extra_args):  # FIX: C6-RT-05
+        """The documented identity actions parse (no argparse 'invalid choice') and FAIL CLOSED - the unwired clawguard/shield integration must never report a false containment."""  # FIX: C6-RT-05
+        module, log_dir, *_rest = _load_auto_containment_module(tmp_path)  # FIX: C6-RT-05
+        rc = _run_auto_containment(module, ["--action", action, *extra_args, "--reason", "Prompt injection - IRP-002"])  # FIX: C6-RT-05
+        assert rc == 1  # FIX: C6-RT-05 - fail closed: nonzero exit, never success
+        report = _read_single_report(log_dir)  # FIX: C6-RT-05
+        assert report["actions_taken"][0]["action"] == action  # FIX: C6-RT-05
+        assert report["actions_taken"][0]["status"] == "failed"  # FIX: C6-RT-05
+        error_text = report["actions_taken"][0]["details"]["error"].lower()  # FIX: C6-RT-05
+        assert "not wired" in error_text and "clawguard" in error_text  # FIX: C6-RT-05 - documented integration contract is surfaced
 
 
 class TestForensicsCollectorRuntimeParity:

--- a/tests/integration/test_playbook_procedures.py
+++ b/tests/integration/test_playbook_procedures.py
@@ -23,7 +23,7 @@ import importlib.util  # FIX: C5-finding-3
 import sys
 
 import pytest
-from unittest.mock import Mock, MagicMock, patch, call
+from unittest.mock import Mock, MagicMock, patch
 from datetime import datetime, timezone
 import json
 from pathlib import Path  # FIX: C5-finding-3
@@ -326,17 +326,19 @@ class TestAutoContainmentCliParity:
                 module.main()  # FIX: C5-finding-3
         assert exc_info.value.code == 0  # FIX: C5-finding-3
         help_output = capsys.readouterr().out  # FIX: C5-finding-3
-        assert "isolate-ec2" in help_output  # FIX: C5-finding-3
-        assert "revoke-credentials" in help_output  # FIX: C5-finding-3
-        assert "isolate-docker" in help_output  # FIX: C5-finding-3
-        assert "block_ip" in help_output  # FIX: C5-finding-3
-        assert "block_domain" in help_output  # FIX: C5-finding-3
-        assert "isolate_container" in help_output  # FIX: C5-finding-3
-        assert "update_rate_limits" in help_output  # FIX: C5-finding-3
-        assert "disable_account" in help_output  # FIX: C6-RT-05
-        assert "revoke_all_sessions" in help_output  # FIX: C6-RT-05
-        assert "enable_account" in help_output  # FIX: C6-RT-05
-        assert "permanent_ban" in help_output  # FIX: C6-RT-05
+        # Canonical kebab-case action names are the documented/preferred spelling.  # FIX: C6-RT-05
+        for action in [  # FIX: C6-RT-05
+            "isolate-ec2", "revoke-credentials", "isolate-docker", "block-ip",  # FIX: C6-RT-05
+            "block-domain", "isolate-container", "update-rate-limits",  # FIX: C6-RT-05
+            "disable-account", "revoke-all-sessions", "enable-account", "permanent-ban",  # FIX: C6-RT-05
+            "kill-skill",  # FIX: C6-RT-05
+        ]:  # FIX: C6-RT-05
+            assert action in help_output, f"canonical action {action!r} missing from --help"  # FIX: C6-RT-05
+        # Backward-compatible snake_case aliases must be documented as accepted so  # FIX: C6-RT-05
+        # operators with existing runbooks know the old spellings still work.  # FIX: C6-RT-05
+        assert "alias" in help_output.lower()  # FIX: C6-RT-05
+        for alias in ["block_ip", "block_domain", "isolate_container", "update_rate_limits", "disable_account", "revoke_all_sessions", "enable_account", "permanent_ban", "kill_skill"]:  # FIX: C6-RT-05
+            assert alias in help_output, f"snake_case alias {alias!r} should be documented in --help"  # FIX: C6-RT-05
 
     @pytest.mark.parametrize(  # FIX: C5-finding-3
         ("args", "expected_action", "expected_target", "expected_reason", "expected_mode"),  # FIX: C5-finding-3
@@ -375,7 +377,12 @@ class TestAutoContainmentCliParity:
     def test_auto_containment_accepts_documented_playbook_commands(  # FIX: C5-finding-3
         self, tmp_path, args, expected_action, expected_target, expected_reason, expected_mode  # FIX: C5-finding-3
     ):  # FIX: C5-finding-3
-        module, log_dir, _fake_ec2, _fake_route53resolver, fake_docker_client, fake_network, fake_container = _load_auto_containment_module(tmp_path)  # FIX: C5-finding-3
+        module, log_dir, fake_ec2, _fake_route53resolver, fake_docker_client, fake_network, fake_container = _load_auto_containment_module(tmp_path)  # FIX: C5-finding-3  # FIX: C6-RT-05 - bind fake_ec2 to configure the NACL below
+        # C6-H-01 hardened _resolve_network_acl_id to FAIL CLOSED instead of fabricating  # FIX: C6-RT-05
+        # a NACL, so block_ip's claim is only provable against a configured NACL: model one.  # FIX: C6-RT-05
+        fake_ec2.describe_network_acls.return_value = {"NetworkAcls": [{"NetworkAclId": "acl-default"}]}  # FIX: C6-RT-05
+        # block_domain refuses to create an unenforced DNS firewall list, so model a configured id.  # FIX: C6-RT-05
+        module.DNS_FIREWALL_DOMAIN_LIST_ID = "fdl-test"  # type: ignore[attr-defined]  # FIX: C6-RT-05
         assert _run_auto_containment(module, args) == 0  # FIX: C5-finding-3
         report = _read_single_report(log_dir)  # FIX: C5-finding-3
         assert report["actions_taken"][0]["action"] == expected_action  # FIX: C5-finding-3
@@ -388,7 +395,15 @@ class TestAutoContainmentCliParity:
         if expected_action == "isolate_container":  # FIX: C5-finding-3
             fake_docker_client.containers.get.assert_called_once_with("agent-prod-42")  # FIX: C5-finding-3
             fake_network.disconnect.assert_called()  # FIX: C5-finding-3
-            fake_container.update.assert_called_once()  # FIX: C5-finding-3
+            # C6-H-07: Docker container labels are immutable post-creation, so quarantine  # FIX: C6-RT-05
+            # state is persisted to a JSONL manifest instead of container.update(labels=...),  # FIX: C6-RT-05
+            # which would raise TypeError at runtime. Assert the manifest, not the mutation.  # FIX: C6-RT-05
+            fake_container.update.assert_not_called()  # FIX: C6-RT-05
+            manifest_files = list(log_dir.glob("*-quarantined-containers.jsonl"))  # FIX: C6-RT-05
+            assert len(manifest_files) == 1, f"expected one quarantine manifest, got {manifest_files!r}"  # FIX: C6-RT-05
+            manifest_record = json.loads(manifest_files[0].read_text(encoding="utf-8").splitlines()[0])  # FIX: C6-RT-05
+            assert manifest_record["container_id"] == "agent-prod-42"  # FIX: C6-RT-05
+            assert set(manifest_record["original_networks"]) == {"openclaw-network", "bridge"}  # FIX: C6-RT-05
 
     @pytest.mark.parametrize(  # FIX: C6-RT-05
         ("action", "extra_args"),  # FIX: C6-RT-05
@@ -410,6 +425,41 @@ class TestAutoContainmentCliParity:
         assert report["actions_taken"][0]["status"] == "failed"  # FIX: C6-RT-05
         error_text = report["actions_taken"][0]["details"]["error"].lower()  # FIX: C6-RT-05
         assert "not wired" in error_text and "clawguard" in error_text  # FIX: C6-RT-05 - documented integration contract is surfaced
+        # Failure path must still capture the action-specific inputs that were attempted,  # FIX: C6-RT-05
+        # so the report records WHAT was requested even though the integration is unwired.  # FIX: C6-RT-05
+        details = report["actions_taken"][0]["details"]  # FIX: C6-RT-05
+        assert details.get("reason") == "Prompt injection - IRP-002"  # FIX: C6-RT-05
+        if action == "disable_account":  # FIX: C6-RT-05
+            assert details.get("duration") == "24h"  # FIX: C6-RT-05 - attempted duration captured
+        if action == "enable_account":  # FIX: C6-RT-05
+            assert details.get("send_warning_email") is True  # FIX: C6-RT-05 - attempted flag captured
+
+    def test_kill_skill_is_accepted_but_fails_closed(self, tmp_path):  # FIX: C6-RT-05
+        """kill_skill parses (no argparse 'invalid choice') and FAILS CLOSED - the unwired openclaw-shield skill-enforcement integration must never report a false containment."""  # FIX: C6-RT-05
+        module, log_dir, *_rest = _load_auto_containment_module(tmp_path)  # FIX: C6-RT-05
+        rc = _run_auto_containment(module, ["--action", "kill_skill", "--agent-id", "agent-prod-12", "--skill-name", "@attacker/credential-stealer", "--reason", "Malicious skill - IRP-003"])  # FIX: C6-RT-05
+        assert rc == 1  # FIX: C6-RT-05 - fail closed: nonzero exit, never success
+        report = _read_single_report(log_dir)  # FIX: C6-RT-05
+        assert report["actions_taken"][0]["action"] == "kill_skill"  # FIX: C6-RT-05 - snake_case audit-log name (consistent with other actions)
+        assert report["actions_taken"][0]["target"] == "agent-prod-12"  # FIX: C6-RT-05
+        assert report["actions_taken"][0]["status"] == "failed"  # FIX: C6-RT-05
+        error_text = report["actions_taken"][0]["details"]["error"].lower()  # FIX: C6-RT-05
+        assert "not wired" in error_text and "openclaw-shield" in error_text  # FIX: C6-RT-05 - documented integration contract is surfaced
+
+    @pytest.mark.parametrize(  # FIX: C6-RT-05
+        "action",  # FIX: C6-RT-05
+        ["disable_account", "revoke_all_sessions", "enable_account", "permanent_ban"],  # FIX: C6-RT-05
+    )  # FIX: C6-RT-05
+    def test_identity_actions_require_user_id_via_argparse_error(self, tmp_path, action):  # FIX: C6-RT-05
+        """Omitting --user-id for an identity action must exit via an argparse usage error
+        (SystemExit code 2), NOT the fail-closed exit(1) path, and must write NO containment
+        report -- so a missing-argument invocation can never look like a successful containment.
+        """  # FIX: C6-RT-05
+        module, log_dir, *_rest = _load_auto_containment_module(tmp_path)  # FIX: C6-RT-05
+        with pytest.raises(SystemExit) as exc_info:  # FIX: C6-RT-05
+            _run_auto_containment(module, ["--action", action, "--reason", "missing user id"])  # FIX: C6-RT-05
+        assert exc_info.value.code == 2  # FIX: C6-RT-05 - argparse usage error (parser.error), distinct from fail-closed exit(1)
+        assert list(log_dir.glob("*-report.json")) == []  # FIX: C6-RT-05 - parser.error fires before save_containment_report(); no misleading success report
 
 
 class TestForensicsCollectorRuntimeParity:
@@ -704,7 +754,7 @@ class TestRecoveryPhase:
         backup_path.write_bytes(b"compressed-backup")  # FIX: C5-finding-3
         manager = module.DisasterRecoveryManager(module.BackupStrategy())  # FIX: C5-finding-3
 
-        with patch.object(module.BackupVerifier, "verify_backup_integrity", return_value=(True, [])), patch.object(module.BackupVerifier, "_verify_database_records", return_value={"users": 10, "sessions": 5}), patch.object(module.DisasterRecoveryManager, "_run_smoke_tests", return_value=None), patch.object(module.subprocess, "run", return_value=SimpleNamespace(returncode=0)) as mock_run:  # FIX: C5-finding-3
+        with patch.object(module.BackupVerifier, "verify_backup_integrity", return_value=(True, [])), patch.object(module.BackupVerifier, "verify_database_records", return_value={"users": 10, "sessions": 5}), patch.object(module.DisasterRecoveryManager, "_run_smoke_tests", return_value=None), patch.object(module.subprocess, "run", return_value=SimpleNamespace(returncode=0)) as mock_run:  # FIX: C5-finding-3  # FIX: C6-RT-05 - patch the public verify_database_records (BackupVerifier has no _verify_database_records; execute_recovery calls the public method)
             metrics = manager.execute_recovery(str(backup_path), "postgresql://restore-target")  # FIX: C5-finding-3
 
         assert metrics.meets_rto is True  # FIX: C5-finding-3


### PR DESCRIPTION
The prompt-injection playbook advertised 4 nonexistent identity actions (disable_account, revoke_all_sessions, enable_account, permanent_ban) + flags (--user-id, --send-warning-email) operating on a user identity by email; argparse rejected them and no repo action disables an external identity. Per user decision (Option B) and Rule 4, these are now real CLI actions backed by fail-closed NotImplementedError stubs: each raises with the full clawguard (policy: POST {policy,subject}->{allowed,reason}) / openclaw-shield (enforce: POST {action,target}->{applied}) contract + required env vars, and main() catches it explicitly to log the action failed and exit non-zero - never fake success, never a silent no-op, never an uncaught traceback. Adds --user-id/--send-warning-email args, parametrized fail-closed tests, and honest playbook notes that these actions fail closed until the integration is wired. Existing actions unchanged. Evidence: each action -> exit 1 + documented contract (0 tracebacks); argparse still rejects bogus actions; tests/security 145/2.