### PR TITLE
feat(C6-RT-06): add fail-closed --find-skill to skill_integrity_monitor (refuses to fabricate affected agents)

### DIFF
--- a/examples/incident-response/playbook-skill-compromise.md
+++ b/examples/incident-response/playbook-skill-compromise.md
@@ -261,7 +261,15 @@
    - **Approved in Allowlist**: ❌ No
 
 3. **Determine Scope**
-   
+
+   > **⚠ `--find-skill` requires an external agent inventory and currently fails closed.**
+   > Mapping a skill to the agents that have it installed needs the orchestration platform's
+   > agent→skill inventory (per the DEPENDENCY NOTICE), which this repo-local monitor does not
+   > have. `--find-skill` is a real, accepted option, but it **exits non-zero with a documented
+   > contract and writes no file** until that inventory is wired — it will never fabricate
+   > `affected_agents`. Obtain `affected-agents.json` from your orchestration platform /
+   > telemetry in the schema shown below, then run the downstream steps.
+
    ```bash
    # Find all agents with malicious skill installed
    ./scripts/supply-chain/skill_integrity_monitor.sh \

--- a/scripts/supply-chain/skill_integrity_monitor.sh
+++ b/scripts/supply-chain/skill_integrity_monitor.sh
@@ -1164,10 +1164,21 @@ find_skill() {  ## FIX: C6-RT-06 - fail-closed stub; refuses to fabricate the af
     ## FIX: C6-RT-06 - agent->skill inventory (the orchestration platform's installed-skills
     ## FIX: C6-RT-06 - export). It is NOT available to this repo-local monitor, so we fail
     ## FIX: C6-RT-06 - closed: write nothing and return non-zero rather than fabricate data.
-    error "--find-skill is not wired for '$skill_name': listing the agents that have a skill installed requires an external agent->skill inventory (the orchestration platform's installed-skills export, e.g. exported to \$OPENCLAW_AGENT_INVENTORY as JSON {\"agents\":[{\"agent_id\":...,\"skills\":[{\"name\":...,\"installation_date\":...}]}]}). No such inventory is available here; refusing to fabricate affected_agents. Obtain the affected-agent list from your orchestration platform/telemetry, then resume the playbook."  ## FIX: C6-RT-06
+    ## FIX: C6-RT-06 - Keep the logged line short and scannable (error() duplicates it into the
+    ## FIX: C6-RT-06 - log); print the full integration contract + JSON schema example as a
+    ## FIX: C6-RT-06 - separate indented block to stdout only, which is NOT logged.
+    error "--find-skill is not wired for '$skill_name': refusing to fabricate affected_agents (no agent->skill inventory available)."  ## FIX: C6-RT-06
     if [ -n "$output_file" ]; then  ## FIX: C6-RT-06
         error "Refusing to write '$output_file' (it would contain fabricated affected-agent data)."  ## FIX: C6-RT-06
     fi  ## FIX: C6-RT-06
+    cat <<'EOF'  ## FIX: C6-RT-06 - operator guidance + contract; stdout only, deliberately not logged
+  Why: mapping a skill to the agents that have it installed needs the orchestration
+       platform's installed-skills export; this repo-local monitor has no such inventory.
+  Resolve: export it to $OPENCLAW_AGENT_INVENTORY as JSON, e.g.
+       {"agents":[{"agent_id":"...","skills":[{"name":"...","installation_date":"..."}]}]}
+       then take the affected-agent list from that export / your telemetry and resume.
+  Docs: examples/incident-response/playbook-skill-compromise.md
+EOF
     return 1  ## FIX: C6-RT-06 - fail closed
 }  ## FIX: C6-RT-06
 
@@ -1322,8 +1333,32 @@ main() {
         --find-skill)  ## FIX: C6-RT-06
             action="find_skill"  ## FIX: C6-RT-06
             arg="${2:-}"  ## FIX: C6-RT-06 - skill name
-            if [ "${3:-}" = "--output" ]; then  ## FIX: C6-RT-06 - optional "--output <file>" follows the skill name
-                output_file="${4:-}"  ## FIX: C6-RT-06
+            ## FIX: C6-RT-06 - Validate at parse time. A missing skill name, or one that looks like
+            ## FIX: C6-RT-06 - a flag (e.g. "--find-skill --output foo"), must be rejected rather than
+            ## FIX: C6-RT-06 - silently consumed as the skill name. Reject any leading-dash value:
+            ## FIX: C6-RT-06 - skill names are never option-like, so this is safe and option-injection-proof.
+            case "$arg" in  ## FIX: C6-RT-06
+                ""|-*)  ## FIX: C6-RT-06
+                    error "--find-skill requires a skill name; usage: --find-skill SKILL [--output FILE]"  ## FIX: C6-RT-06
+                    exit 1  ## FIX: C6-RT-06
+                    ;;  ## FIX: C6-RT-06
+            esac  ## FIX: C6-RT-06
+            if [ -n "${3:-}" ]; then  ## FIX: C6-RT-06 - the only token allowed after SKILL is "--output FILE"
+                if [ "${3:-}" != "--output" ]; then  ## FIX: C6-RT-06
+                    error "Unexpected argument '$3' after --find-skill SKILL; expected '--output FILE'"  ## FIX: C6-RT-06
+                    exit 1  ## FIX: C6-RT-06
+                fi  ## FIX: C6-RT-06
+                output_file="${4:-}"  ## FIX: C6-RT-06 - require a real path, not a missing/flag-like value
+                case "$output_file" in  ## FIX: C6-RT-06
+                    ""|-*)  ## FIX: C6-RT-06
+                        error "--output requires a file path argument (got '${output_file:-<none>}')"  ## FIX: C6-RT-06
+                        exit 1  ## FIX: C6-RT-06
+                        ;;  ## FIX: C6-RT-06
+                esac  ## FIX: C6-RT-06
+                if [ -n "${5:-}" ]; then  ## FIX: C6-RT-06 - reject trailing junk after "--output FILE"
+                    error "Unexpected argument '$5' after --find-skill SKILL --output FILE"  ## FIX: C6-RT-06
+                    exit 1  ## FIX: C6-RT-06
+                fi  ## FIX: C6-RT-06
             fi  ## FIX: C6-RT-06
             ;;  ## FIX: C6-RT-06
         --help)

--- a/scripts/supply-chain/skill_integrity_monitor.sh
+++ b/scripts/supply-chain/skill_integrity_monitor.sh
@@ -1157,6 +1157,20 @@ clean_quarantine() {
     fi
 }
 
+find_skill() {  ## FIX: C6-RT-06 - fail-closed stub; refuses to fabricate the affected-agents inventory
+    local skill_name="$1"  ## FIX: C6-RT-06
+    local output_file="${2:-}"  ## FIX: C6-RT-06
+    ## FIX: C6-RT-06 - Listing the agents that have a skill installed requires an external
+    ## FIX: C6-RT-06 - agent->skill inventory (the orchestration platform's installed-skills
+    ## FIX: C6-RT-06 - export). It is NOT available to this repo-local monitor, so we fail
+    ## FIX: C6-RT-06 - closed: write nothing and return non-zero rather than fabricate data.
+    error "--find-skill is not wired for '$skill_name': listing the agents that have a skill installed requires an external agent->skill inventory (the orchestration platform's installed-skills export, e.g. exported to \$OPENCLAW_AGENT_INVENTORY as JSON {\"agents\":[{\"agent_id\":...,\"skills\":[{\"name\":...,\"installation_date\":...}]}]}). No such inventory is available here; refusing to fabricate affected_agents. Obtain the affected-agent list from your orchestration platform/telemetry, then resume the playbook."  ## FIX: C6-RT-06
+    if [ -n "$output_file" ]; then  ## FIX: C6-RT-06
+        error "Refusing to write '$output_file' (it would contain fabricated affected-agent data)."  ## FIX: C6-RT-06
+    fi  ## FIX: C6-RT-06
+    return 1  ## FIX: C6-RT-06 - fail closed
+}  ## FIX: C6-RT-06
+
 # ============================================================================
 # MAIN FUNCTION
 # ============================================================================
@@ -1179,6 +1193,8 @@ OPTIONS:
     --cleanup            Clean up old logs and quarantine
     --status             Show monitoring status
     --report             Generate security report
+    --find-skill SKILL   Find agents with SKILL installed (requires external agent inventory; currently fails closed)
+    --output FILE        Output path for --find-skill results (only used with --find-skill)
     --help               Show this help message
 
 EXAMPLES:
@@ -1270,6 +1286,7 @@ main() {
 
     local action=""
     local arg=""
+    local output_file=""  ## FIX: C6-RT-06
 
     case "$1" in
         --start)
@@ -1302,6 +1319,13 @@ main() {
         --report)
             action="report"
             ;;
+        --find-skill)  ## FIX: C6-RT-06
+            action="find_skill"  ## FIX: C6-RT-06
+            arg="${2:-}"  ## FIX: C6-RT-06 - skill name
+            if [ "${3:-}" = "--output" ]; then  ## FIX: C6-RT-06 - optional "--output <file>" follows the skill name
+                output_file="${4:-}"  ## FIX: C6-RT-06
+            fi  ## FIX: C6-RT-06
+            ;;  ## FIX: C6-RT-06
         --help)
             show_help
             exit 0
@@ -1348,6 +1372,14 @@ main() {
             fi
             restore_skill "$arg"
             ;;
+        find_skill)  ## FIX: C6-RT-06
+            if [ -z "$arg" ]; then  ## FIX: C6-RT-06
+                error "--find-skill requires a skill name"  ## FIX: C6-RT-06
+                exit 1  ## FIX: C6-RT-06
+            fi  ## FIX: C6-RT-06
+            find_skill "$arg" "$output_file"  ## FIX: C6-RT-06
+            exit $?  ## FIX: C6-RT-06 - propagate the fail-closed status
+            ;;  ## FIX: C6-RT-06
         cleanup)
             cleanup
             ;;

--- a/tests/integration/test_skill_find_skill.py
+++ b/tests/integration/test_skill_find_skill.py
@@ -1,0 +1,105 @@
+"""C6-RT-06 regression tests — fail-closed `--find-skill` in skill_integrity_monitor.sh.
+
+Claim: the skill-compromise playbook advertises
+  `skill_integrity_monitor.sh --find-skill <skill> --output affected-agents.json`.
+That command must be a real, accepted option, but since mapping a skill to the agents
+that have it installed requires an EXTERNAL agent->skill inventory (not available to this
+repo-local monitor), `find_skill` must FAIL CLOSED: return non-zero, write no output file,
+and surface the documented contract — never fabricate an affected_agents list.
+
+These drive the real bash `find_skill` function by sourcing the monitor script with its
+`main` dispatch suppressed (BASH_SOURCE guard), inside an isolated sandbox. Mirrors the
+bash-mount-path handling used by test_skill_restore_origin.py.
+"""
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MONITOR_SCRIPT = _REPO_ROOT / "scripts" / "supply-chain" / "skill_integrity_monitor.sh"
+_BASH_PATH = shutil.which("bash")
+
+
+def _detect_bash_mount_root(bash_path: str | None) -> str:
+    """WSL mounts C: at /mnt/c; Git Bash / MSYS / Cygwin mount it at /c."""
+    if not bash_path:
+        return "/mnt/"
+    try:
+        proc = subprocess.run(
+            [bash_path, "--version"], capture_output=True, text=True, check=False, timeout=5
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "/mnt/"
+    banner = (proc.stdout + proc.stderr).lower()
+    if "cygwin" in banner or "msys" in banner or "mingw" in banner:
+        return "/"
+    return "/mnt/"
+
+
+def _to_bash_path(path: Path, bash_path: str | None = None) -> str:
+    """Convert an absolute path to the bash mount path for this flavor."""
+    if sys.platform != "win32":
+        return path.as_posix()
+    drive_letter = path.drive.rstrip(":").lower()
+    rest = path.as_posix()[len(path.drive):]
+    return f"{_detect_bash_mount_root(bash_path)}{drive_letter}{rest}"
+
+
+# Driver: source the monitor (main suppressed), isolate OPENCLAW_LOGS into the sandbox, then
+# call find_skill directly and report RC, whether an output file was (wrongly) written, and the message.
+_FIND_SKILL_DRIVER = r'''
+SCRIPT="$1"; SB="$2"
+export OPENCLAW_LOGS="$SB/logs"
+mkdir -p "$SB/logs"
+# shellcheck disable=SC1090
+source "$SCRIPT"
+set +e   # find_skill returns non-zero on the fail-closed path; capture $? rather than abort (errexit was set by the sourced script)
+OUT="$SB/affected-agents.json"
+find_skill "@attacker/credential-stealer" "$OUT" >"$SB/out.txt" 2>&1
+echo "RC=$?"
+[ -f "$OUT" ] && echo "OUTFILE=created" || echo "OUTFILE=absent"
+echo "MSG<<"; cat "$SB/out.txt" 2>/dev/null; echo ">>MSG"
+'''
+
+
+def _run_find_skill(tmp_path: Path) -> str:
+    assert _BASH_PATH, "bash is required for these tests"
+    sandbox = tmp_path / "sb"
+    sandbox.mkdir()
+    out = subprocess.run(
+        [
+            _BASH_PATH, "-c", _FIND_SKILL_DRIVER, "driver",
+            _to_bash_path(_MONITOR_SCRIPT, _BASH_PATH),
+            _to_bash_path(sandbox, _BASH_PATH),
+        ],
+        capture_output=True, text=True, check=False, timeout=60,
+    )
+    return out.stdout + out.stderr
+
+
+pytestmark = pytest.mark.skipif(_BASH_PATH is None, reason="bash not available")
+
+
+def test_find_skill_fails_closed_and_writes_nothing(tmp_path):
+    """find_skill must refuse to fabricate affected agents: non-zero, no output file, documented contract."""
+    out = _run_find_skill(tmp_path)
+    assert "RC=1" in out, out                 # fail closed (non-zero)
+    assert "OUTFILE=absent" in out, out        # no fabricated affected-agents.json written
+    low = out.lower()
+    assert "not wired" in low, out             # documented contract surfaced
+    assert "refusing to fabricate" in low, out
+
+
+def test_help_lists_find_skill(tmp_path):
+    """--find-skill is a documented option (and --help is handled before initialize)."""
+    assert _BASH_PATH, "bash is required for these tests"
+    proc = subprocess.run(
+        [_BASH_PATH, _to_bash_path(_MONITOR_SCRIPT, _BASH_PATH), "--help"],
+        capture_output=True, text=True, check=False, timeout=30,
+    )
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode == 0, combined
+    assert "--find-skill" in combined, combined

--- a/tests/integration/test_skill_find_skill.py
+++ b/tests/integration/test_skill_find_skill.py
@@ -11,6 +11,7 @@ These drive the real bash `find_skill` function by sourcing the monitor script w
 `main` dispatch suppressed (BASH_SOURCE guard), inside an isolated sandbox. Mirrors the
 bash-mount-path handling used by test_skill_restore_origin.py.
 """
+import os
 import shutil
 import subprocess
 import sys
@@ -93,6 +94,26 @@ def test_find_skill_fails_closed_and_writes_nothing(tmp_path):
     assert "refusing to fabricate" in low, out
 
 
+def test_find_skill_logs_concise_message_not_full_schema(tmp_path):
+    """The dense JSON-schema contract reaches the operator (stdout) but must NOT bloat the log.
+
+    Copilot review: keep the logged line short and scannable; print the schema example as a
+    separate block instead of duplicating it into skill_monitor.log on every fail-closed call.
+    """
+    out = _run_find_skill(tmp_path)
+    # Operator-facing stdout still carries the full guidance: schema example + docs pointer.
+    assert "agent_id" in out, out
+    assert "installation_date" in out, out
+    assert "playbook-skill-compromise.md" in out, out
+    # The log records the fail-closed event concisely, WITHOUT the dense schema.
+    log_file = tmp_path / "sb" / "logs" / "skill_monitor.log"
+    assert log_file.exists(), "fail-closed event should be logged"
+    log_text = log_file.read_text(encoding="utf-8", errors="replace")
+    assert "not wired" in log_text.lower(), log_text          # event is logged...
+    assert "agent_id" not in log_text, log_text               # ...but the schema is not
+    assert '{"agents"' not in log_text, log_text
+
+
 def test_help_lists_find_skill(tmp_path):
     """--find-skill is a documented option (and --help is handled before initialize)."""
     assert _BASH_PATH, "bash is required for these tests"
@@ -103,3 +124,79 @@ def test_help_lists_find_skill(tmp_path):
     combined = proc.stdout + proc.stderr
     assert proc.returncode == 0, combined
     assert "--find-skill" in combined, combined
+
+
+# ---------------------------------------------------------------------------
+# C6-RT-06 argument-parsing hardening (Copilot review).
+# `--find-skill` arg validation runs during parsing, BEFORE initialize() (which
+# needs jq/sha256sum/curl + policy files), so these malformed-invocation cases
+# exit cleanly without those deps. We isolate the log dir into the sandbox so
+# error()/log() write there instead of $HOME/.openclaw/logs.
+# ---------------------------------------------------------------------------
+def _run_monitor_cli(args, tmp_path):
+    """Invoke the monitor's CLI dispatch (main) with ARGS in an isolated sandbox."""
+    assert _BASH_PATH, "bash is required for these tests"
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    env = {**os.environ, "OPENCLAW_LOGS": _to_bash_path(logs, _BASH_PATH)}
+    return subprocess.run(
+        [_BASH_PATH, _to_bash_path(_MONITOR_SCRIPT, _BASH_PATH), *args],
+        capture_output=True, text=True, check=False, timeout=60, env=env,
+    )
+
+
+def test_find_skill_rejects_flag_as_skill_name(tmp_path):
+    """`--find-skill --output foo` must NOT consume --output as the skill name; reject it."""
+    out = tmp_path / "affected-agents.json"
+    proc = _run_monitor_cli(["--find-skill", "--output", _to_bash_path(out, _BASH_PATH)], tmp_path)
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode != 0, combined
+    assert "requires a skill name" in combined.lower(), combined
+    assert not out.exists(), "no output file may be written for a malformed invocation"
+
+
+def test_find_skill_missing_skill_name(tmp_path):
+    """`--find-skill` with no skill name is rejected."""
+    proc = _run_monitor_cli(["--find-skill"], tmp_path)
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode != 0, combined
+    assert "requires a skill name" in combined.lower(), combined
+
+
+def test_find_skill_output_flag_without_path(tmp_path):
+    """`--find-skill SKILL --output` (missing file) must error, not silently set an empty output."""
+    proc = _run_monitor_cli(["--find-skill", "@attacker/credential-stealer", "--output"], tmp_path)
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode != 0, combined
+    assert "--output requires a file path" in combined.lower(), combined
+
+
+def test_find_skill_rejects_flaglike_output_path(tmp_path):
+    """`--output --evil` must be rejected (option-injection-proof)."""
+    proc = _run_monitor_cli(
+        ["--find-skill", "@attacker/credential-stealer", "--output", "--evil"], tmp_path
+    )
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode != 0, combined
+    assert "--output requires a file path" in combined.lower(), combined
+
+
+def test_find_skill_rejects_unexpected_trailing_arg(tmp_path):
+    """A third token that isn't --output is rejected, not silently ignored."""
+    proc = _run_monitor_cli(["--find-skill", "@attacker/credential-stealer", "garbage"], tmp_path)
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode != 0, combined
+    assert "unexpected argument" in combined.lower(), combined
+
+
+def test_find_skill_rejects_trailing_junk_after_output(tmp_path):
+    """Extra args after `--output FILE` are rejected and nothing is written."""
+    out = tmp_path / "affected-agents.json"
+    proc = _run_monitor_cli(
+        ["--find-skill", "@attacker/x", "--output", _to_bash_path(out, _BASH_PATH), "extra"],
+        tmp_path,
+    )
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode != 0, combined
+    assert "unexpected argument" in combined.lower(), combined
+    assert not out.exists(), combined


### PR DESCRIPTION
The skill-compromise playbook advertised 'skill_integrity_monitor.sh --find-skill <skill> --output affected-agents.json' (load-bearing across the runbook), but no such option existed and there is no in-repo agent->skill inventory. Per user decision (Option B, mirroring C6-RT-05), --find-skill / --output are now real, accepted options backed by a fail-closed stub: find_skill() documents the required external agent->skill inventory (OPENCLAW_AGENT_INVENTORY + schema), writes NO output file, and returns non-zero - never fabricating affected_agents. Dispatch propagates the status via 'exit $?'. Adds tests/integration/test_skill_find_skill.py (sources the script, drives find_skill: RC=1 + no output file + documented contract; mirrors the restore-origin harness) and an honest playbook note. Existing options/functions and the BASH_SOURCE guard are unchanged; bash -n clean; tests/security 145/2.