### PR TITLE
fix(C6-CI): repair the three failing Security Scanning jobs and make the hash-verification claim true

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -223,8 +223,14 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Upgrade pip to patched version (CVE-2026-3219)
-        run: python -m pip install --upgrade "pip>=26.1"
+      # `pip-audit` with no --requirement argument audits the packages installed in the
+      # ambient environment, which on a GitHub-hosted runner includes the preinstalled
+      # pip/setuptools/wheel. setuptools 79.0.1 shipped by the runner carries
+      # PYSEC-2026-3447 (MANIFEST.in exclusions silently bypassed when a pattern and an
+      # on-disk filename differ only by Unicode normalisation), which is what failed this
+      # job on every run. Raising the floor to the patched release clears it. # FIX: C6-CI-04
+      - name: Upgrade pip and build tooling to patched versions (CVE-2026-3219, PYSEC-2026-3447)
+        run: python -m pip install --upgrade "pip>=26.1" "setuptools>=83.0.0" # FIX: C6-CI-04
 
       - name: Install pip-audit
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,10 @@ CLAUDE.md
 .mcp.json
 setup-claude-config.sh
 .github/audit
+
+# ClaudeMemoryVault — added to the VS Code multi-root workspace; never commit it into this repo.
+# Scoped to the exact folder name so the tracked configs/agent-config/secrets-template.vault is unaffected.
+ClaudeMemoryVault/
+ClaudeMemoryVault
+# VS Code multi-root workspace files (they list machine-specific absolute paths, e.g. the vault)
+*.code-workspace

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,23 +1,56 @@
 [extend]
 useDefault = true
 
-[[allowlists]]
-description = "Threat scenario documentation intentionally demonstrates credential patterns"
-paths = [
-  '''examples/scenarios/''',
-]
+# FIX: C6-CI-01 — Collapsed the three `[[allowlists]]` array-of-tables blocks into a
+# single singular `[allowlist]` table.
+#
+# Why: gitleaks-action@v2 resolves and runs gitleaks 8.24.3, which reads only the
+# singular `allowlist` key from the config. The plural global `[[allowlists]]` form is
+# a newer addition, so 8.24.3 parsed the config successfully (the run log confirms
+# "using gitleaks config from GITLEAKS_CONFIG env var: .gitleaks.toml") and then
+# silently ignored every allowlist, reporting 22 findings in threat-scenario
+# documentation. The singular form is honoured by every gitleaks 8.x, so this stays
+# correct whether or not the action's pinned version moves forward.
+#
+# Scope note: this allowlist suppresses only synthetic placeholder credentials in
+# documentation and templates. Every entry below was inspected line-by-line and
+# contains a redaction marker, never a real secret. Source code paths
+# (scripts/, tools/, src/, detections/, configs/ other than the vault template) are
+# deliberately NOT allowlisted, so a real leak there still fails the scan.
+[allowlist]
+description = "Synthetic placeholder credentials in threat-scenario docs and templates"
 
-[[allowlists]]
-description = "Secrets vault template uses masked placeholder examples"
+# Criteria below are OR'd: a finding is allowlisted if its path OR its secret matches.
 paths = [
+  # Threat scenario documentation intentionally demonstrates credential patterns.
+  '''examples/scenarios/''',
+  # Secrets vault template uses masked placeholder examples.
   '''secrets-template\.vault''',
 ]
 
-[[allowlists]]
-description = "Placeholder-style redaction markers used in place of real secrets"
+# gitleaks runs `detect`, which scans the full commit history (363 commits), so findings
+# persist even after the working tree is cleaned up. This matches one specific synthetic
+# value committed in the initial commit (5343fe47) at
+# docs/compliance/audit-configuration.md:390, where an illustrative Stripe key was written
+# out before it was replaced with FULL_API_KEY_REDACTED_FOR_DOCS in the current tree.
+# `abc123def456` is a documentation placeholder, not a live credential — a real Stripe
+# secret key is 24+ random characters. Matching the literal value rather than allowlisting
+# the file by path keeps the file itself scanned, so a genuine future leak there still fails.
+#
+# The pattern deliberately omits the `sk_live_` prefix: gitleaks reports a startColumn one
+# past the true start of the match, so anchoring on the prefix would be sensitive to that
+# off-by-one. `abc123def456` is the placeholder body used consistently across this repo's
+# example credentials (gw_live_abc123def456, sk-prod-abc123def456ghi789, ...).
+regexes = [
+  '''abc123def456''',
+]
+
+# Placeholder-style redaction markers used in place of real secrets.
 stopwords = [
   "_EXAMPLE_NOT_REAL",
   "_PLACEHOLDER",
   "REDACTED",
   "NOT_REAL",
+  "REPLACE_WITH",
+  "redacted example token",
 ]

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,1 +1,98 @@
-PyYAML>=6.0
+# Production runtime dependencies -- fully pinned and hash-locked.
+#
+# Installed by scripts/hardening/docker/Dockerfile.hardened (dependency-builder stage)
+# with `pip install --require-hashes --no-deps`. Both flags are load-bearing:
+#   --require-hashes  every requirement must be pinned with == and carry --hash entries,
+#                     and pip refuses to install any file whose digest does not match.
+#   --no-deps         nothing outside this file may be pulled in, so this file alone is
+#                     the complete, verified dependency set.
+#
+# There is deliberately no unhashed fallback install. If verification fails the build
+# must fail -- silently installing unverified packages would make the Dockerfile's
+# "Hash verification for packages" claim false. # FIX: C6-CI-05
+#
+# All published sha256 digests for the pinned version are listed (every wheel plus the
+# sdist), which is what `pip-compile --generate-hashes` emits. This keeps the lock valid
+# if PYTHON_VERSION or the build architecture changes; the musl x86_64 build currently
+# selects pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl.
+#
+# To regenerate after a version bump:
+#   pip-compile --generate-hashes --output-file requirements-prod.txt requirements-prod.in
+# or query the PyPI JSON API for the target version and list every sha256 digest.
+#
+# Floor of record is `PyYAML>=6.0` in requirements.txt; this file pins the exact release.
+
+PyYAML==6.0.3 \
+    --hash=sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f \
+    --hash=sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4 \
+    --hash=sha256:efd7b85f94a6f21e4932043973a7ba2613b059c4a000551892ac9f1d11f5baf3 \
+    --hash=sha256:22ba7cfcad58ef3ecddc7ed1db3409af68d023b7f940da23c6c2a1890976eda6 \
+    --hash=sha256:6344df0d5755a2c9a276d4473ae6b90647e216ab4757f8426893b5dd2ac3f369 \
+    --hash=sha256:3ff07ec89bae51176c0549bc4c63aa6202991da2d9a6129d7aef7f1407d3f295 \
+    --hash=sha256:5cf4e27da7e3fbed4d6c3d8e797387aaad68102272f8f9752883bc32d61cb87b \
+    --hash=sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b \
+    --hash=sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956 \
+    --hash=sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8 \
+    --hash=sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198 \
+    --hash=sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b \
+    --hash=sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0 \
+    --hash=sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69 \
+    --hash=sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e \
+    --hash=sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c \
+    --hash=sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e \
+    --hash=sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824 \
+    --hash=sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c \
+    --hash=sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00 \
+    --hash=sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d \
+    --hash=sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a \
+    --hash=sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4 \
+    --hash=sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b \
+    --hash=sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf \
+    --hash=sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196 \
+    --hash=sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0 \
+    --hash=sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28 \
+    --hash=sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c \
+    --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc \
+    --hash=sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e \
+    --hash=sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea \
+    --hash=sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5 \
+    --hash=sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b \
+    --hash=sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd \
+    --hash=sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8 \
+    --hash=sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1 \
+    --hash=sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c \
+    --hash=sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5 \
+    --hash=sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6 \
+    --hash=sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6 \
+    --hash=sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be \
+    --hash=sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26 \
+    --hash=sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c \
+    --hash=sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb \
+    --hash=sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac \
+    --hash=sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310 \
+    --hash=sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7 \
+    --hash=sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788 \
+    --hash=sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5 \
+    --hash=sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764 \
+    --hash=sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35 \
+    --hash=sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac \
+    --hash=sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3 \
+    --hash=sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3 \
+    --hash=sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba \
+    --hash=sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c \
+    --hash=sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702 \
+    --hash=sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c \
+    --hash=sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065 \
+    --hash=sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65 \
+    --hash=sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9 \
+    --hash=sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b \
+    --hash=sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da \
+    --hash=sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917 \
+    --hash=sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9 \
+    --hash=sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5 \
+    --hash=sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a \
+    --hash=sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926 \
+    --hash=sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7 \
+    --hash=sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0 \
+    --hash=sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007 \
+    --hash=sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f

--- a/scripts/hardening/docker/Dockerfile.hardened
+++ b/scripts/hardening/docker/Dockerfile.hardened
@@ -91,12 +91,23 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Upgrade pip and install build tools; floors clear CVE-2026-24049 (wheel) and CVE-2024-6345/CVE-2025-47273 (setuptools)
 RUN pip install --no-cache-dir --upgrade pip "setuptools>=78.1.1" "wheel>=0.46.2"
 
-# Install production dependencies with hash verification
+# Install production dependencies with hash verification.
+#
+# This previously ended in `|| pip install -r requirements-prod.txt`, which defeated the
+# entire control: requirements-prod.txt carried `PyYAML>=6.0` with no `==` pin and no
+# digests, so --require-hashes failed on every single build and the unverified install ran
+# instead. The build log for run 31353439888 shows exactly that sequence. The image was
+# therefore never built from hash-verified dependencies, while the header of this file
+# claimed "Hash verification for packages (--require-hashes)".
+#
+# requirements-prod.txt is now pinned with `==` and carries every published sha256 digest
+# for that release, so verification succeeds on its own merits. The unverified path is gone:
+# if a digest ever fails to match, the build fails, which is the only behaviour that makes
+# the claim above true. # FIX: C6-CI-05
 RUN pip install --no-cache-dir \
     --require-hashes \
     --no-deps \
-    -r requirements-prod.txt || \
-    pip install --no-cache-dir -r requirements-prod.txt
+    -r requirements-prod.txt
 
 # Verify installed packages
 RUN pip check && \

--- a/scripts/hardening/docker/Dockerfile.hardened
+++ b/scripts/hardening/docker/Dockerfile.hardened
@@ -154,8 +154,13 @@ RUN trivy filesystem --format cyclonedx --output /scan/sbom.json /scan
 
 FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION} AS runtime-base
 
-# Install runtime dependencies only
-RUN apk add --no-cache \
+# Install runtime dependencies only.
+# `apk upgrade` applies patch-level updates within the pinned ALPINE_VERSION branch. The
+# python:alpine base image lags the Alpine security database, so it shipped
+# libcrypto3/libssl3 3.5.6-r0 while 3.5.7-r0 (CVE-2026-45447, OpenSSL heap
+# use-after-free in PKCS7_verify) was already published. # FIX: C6-CI-02
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
     libffi \
     openssl \
     ca-certificates \
@@ -165,13 +170,6 @@ RUN apk add --no-cache \
     curl \
     && update-ca-certificates
 
-# Upgrade system Python pip/setuptools/wheel; the python:alpine base ships outdated versions
-# carrying CVE-2026-24049 (wheel<0.46.2), CVE-2024-6345 + CVE-2025-47273 (setuptools<78.1.1).
-# Trivy scans /usr/local/lib/python3.11/site-packages directly, so upgrading the venv alone
-# is not enough.
-RUN pip install --no-cache-dir --upgrade \
-        "pip" "setuptools>=78.1.1" "wheel>=0.46.2"
-
 # Create non-root user
 RUN addgroup -g 1000 -S clawdbot && \
     adduser -u 1000 -S clawdbot -G clawdbot -h /app
@@ -179,6 +177,14 @@ RUN addgroup -g 1000 -S clawdbot && \
 # Create necessary directories
 RUN mkdir -p /app/config /app/logs /app/tmp /app/data && \
     chown -R clawdbot:clawdbot /app
+
+# Upgrade system Python pip/setuptools/wheel; the python:alpine base ships outdated versions
+# carrying CVE-2026-24049 (wheel<0.46.2), CVE-2024-6345 + CVE-2025-47273 (setuptools<78.1.1)
+# and PYSEC-2026-3447 (setuptools<83.0.0). This stage keeps pip because the `development`
+# target below builds from it and needs pip to install its tooling; the production targets
+# build from `runtime-hardened`, which removes pip entirely. # FIX: C6-CI-03
+RUN pip install --no-cache-dir --upgrade \
+        "pip" "setuptools>=83.0.0" "wheel>=0.46.2"
 
 # Copy virtual environment from builder
 COPY --from=app-builder --chown=clawdbot:clawdbot /opt/venv /opt/venv
@@ -198,10 +204,57 @@ WORKDIR /app
 USER clawdbot
 
 # ============================================================================
+# STAGE 5b: Hardened Runtime (no package manager)
+# ============================================================================
+# Production images build from here rather than from `runtime-base`. The only difference is
+# that the Python package manager is removed. `development` deliberately keeps it.
+# FIX: C6-CI-03
+
+FROM runtime-base AS runtime-hardened
+
+# Removing pip/setuptools/wheel requires root; the stage drops back to clawdbot at the end.
+USER root
+
+# Remove the Python package manager from the production runtime images.
+#
+# Two reasons, in order of importance:
+#   1. Hardening. A production runtime image has no legitimate need to install packages.
+#      Shipping pip/setuptools/wheel hands an attacker who achieves code execution a
+#      ready-made package installer and an arbitrary-code-execution path via
+#      `setup.py`/`pkg_resources`.
+#   2. It eliminates a class of otherwise unfixable Trivy findings. Trivy's python-pkg
+#      analyzer parses `pip/_vendor/vendor.txt`, which pins `msgpack==1.1.2` and
+#      `setuptools==70.3.0` regardless of what is actually installed. Those pins are
+#      reported as HIGH (GHSA-6v7p-g79w-8964, CVE-2025-47273) and CANNOT be cleared by
+#      upgrading pip — current pip still vendors those versions. Deleting pip removes the
+#      vendored manifest, so the finding goes away because the code is gone, not because it
+#      was suppressed with an ignore rule.
+#
+# Both site-packages trees are purged: the interpreter's own and the venv's. `ensurepip` is
+# removed too, since it bundles the same wheels. Nothing at runtime imports pip, setuptools,
+# or pkg_resources — the entrypoints are shell scripts and the application is installed as a
+# built wheel. The two assertions below fail the build if that ever stops being true.
+RUN for sp in /usr/local/lib/python3.*/site-packages /opt/venv/lib/python3.*/site-packages; do \
+        rm -rf "$sp"/pip "$sp"/pip-*.dist-info \
+               "$sp"/setuptools "$sp"/setuptools-*.dist-info \
+               "$sp"/pkg_resources \
+               "$sp"/wheel "$sp"/wheel-*.dist-info \
+               "$sp"/_distutils_hack "$sp"/distutils-precedence.pth; \
+    done && \
+    rm -rf /usr/local/lib/python3.*/ensurepip && \
+    /opt/venv/bin/python -c "import yaml; print('runtime deps import OK')" && \
+    if /opt/venv/bin/python -c "import pip" 2>/dev/null; then \
+        echo "ERROR: pip still importable after purge" >&2; exit 1; \
+    fi && \
+    echo "pip successfully removed from runtime image"
+
+USER clawdbot
+
+# ============================================================================
 # STAGE 6: Gateway Production Image
 # ============================================================================
 
-FROM runtime-base AS gateway
+FROM runtime-hardened AS gateway
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -247,7 +300,8 @@ CMD ["/app/entrypoint.sh"]
 # STAGE 7: Agent Production Image
 # ============================================================================
 
-FROM runtime-base AS agent
+# Builds from runtime-hardened (no package manager). # FIX: C6-CI-03
+FROM runtime-hardened AS agent
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -294,15 +348,31 @@ CMD ["/app/entrypoint.sh"]
 FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION} AS playbook
 
 # Install only what the playbook tooling needs at runtime.
-RUN apk add --no-cache \
+# `apk upgrade` picks up patched libcrypto3/libssl3 3.5.7-r0 (CVE-2026-45447) that the
+# python:alpine base still ships at 3.5.6-r0. # FIX: C6-CI-02
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
     ca-certificates \
     tini \
     && update-ca-certificates
 
-# Upgrade system Python pip/setuptools/wheel; the python:alpine base ships outdated versions
-# carrying CVE-2026-24049 (wheel<0.46.2), CVE-2024-6345 + CVE-2025-47273 (setuptools<78.1.1).
-RUN pip install --no-cache-dir --upgrade \
-        "pip" "setuptools>=78.1.1" "wheel>=0.46.2"
+# Remove the Python package manager — see the equivalent block in `runtime-base` for the
+# full rationale. In short: this CI image only runs stdlib-based verification tooling, so
+# pip is pure attack surface, and its `_vendor/vendor.txt` pins (msgpack 1.1.2,
+# setuptools 70.3.0) are reported HIGH by Trivy and cannot be fixed by upgrading pip.
+# FIX: C6-CI-03
+RUN for sp in /usr/local/lib/python3.*/site-packages; do \
+        rm -rf "$sp"/pip "$sp"/pip-*.dist-info \
+               "$sp"/setuptools "$sp"/setuptools-*.dist-info \
+               "$sp"/pkg_resources \
+               "$sp"/wheel "$sp"/wheel-*.dist-info \
+               "$sp"/_distutils_hack "$sp"/distutils-precedence.pth; \
+    done && \
+    rm -rf /usr/local/lib/python3.*/ensurepip && \
+    if python -c "import pip" 2>/dev/null; then \
+        echo "ERROR: pip still importable after purge" >&2; exit 1; \
+    fi && \
+    echo "pip successfully removed from playbook image"
 
 # Create non-root user and workspace
 RUN addgroup -g 1000 -S clawdbot && \


### PR DESCRIPTION
Fixes the three `Security Scanning` jobs that had been red on every scheduled run since at least 2026-07-22 (15 consecutive runs), plus a false security claim found while diagnosing them.

Diagnosed from run `31353439888` logs and artifacts — not guessed.

## C6-CI-01 — Secret Detection: 22 leaks, allowlist inert

`gitleaks-action@v2` resolves gitleaks **8.24.3**, which reads only the singular `allowlist` key. The three `[[allowlists]]` array-of-tables blocks parsed fine and were then silently ignored — the run log confirms the config itself loaded. Collapsed into one `[allowlist]` table, honoured by every gitleaks 8.x.

All 22 findings were inspected **in their historical form** (gitleaks scans 363 commits, so the current tree isn't the whole story). Every one is a placeholder: `[REDACTED]`, `REPLACE_WITH_…`, `T00000000/B00000000/XXXX…`, the public JWT header, `abc123def456`. **No live credential; no rotation required.** Source directories are deliberately left unallowlisted so a real leak still fails.

## C6-CI-02 / C6-CI-03 — Trivy Container Scan

Two independent causes:

- `libcrypto3`/`libssl3` 3.5.6-r0 — **CVE-2026-45447** (OpenSSL heap UAF in `PKCS7_verify`), fixed in 3.5.7-r0. The `python:alpine` base lags the Alpine security DB, so `apk upgrade --no-cache` now pulls it, staying inside the pinned 3.22 branch.
- `msgpack 1.1.2` + `setuptools 70.3.0` **are not installed at all**. Trivy parses `pip/_vendor/vendor.txt`, which pins exactly those versions — verified against pip 26.0.1's own vendor.txt. Upgrading pip cannot clear them. A new `runtime-hardened` stage removes pip/setuptools/wheel/`pkg_resources`/`ensurepip` from the production images; `development` still builds from `runtime-base` because it needs pip. The finding clears because the code is gone, **not** via a `.trivyignore`.

## C6-CI-04 — Python Dependency Audit

`pip-audit` with no `--requirement` audits the runner's ambient env, and hosted runners preinstall `setuptools 79.0.1` carrying **PYSEC-2026-3447**. Floor raised to `>=83.0.0`.

## C6-CI-05 — the Dockerfile's hash-verification claim was false

The header claimed *"Hash verification for packages (`--require-hashes`)"*. It never worked once:

```
pip install --require-hashes --no-deps -r requirements-prod.txt || \
    pip install -r requirements-prod.txt
```

`requirements-prod.txt` held `PyYAML>=6.0` — unpinned, no digests — so `--require-hashes` failed on **every** build and the second path installed unverified. Run `31353439888` shows the exact sequence. The unverified path is what kept it invisible.

Now pinned `PyYAML==6.0.3` with all 73 published sha256 digests, and the unverified path is removed.

## Verification

No security gate was weakened: no `exit-code` change, no `.trivyignore`, no `continue-on-error` added, no severity threshold relaxed.

**Container scans, run locally on `linux/amd64` with a freshly pulled base, trivy 0.69.3, CI's exact gate (`--severity CRITICAL,HIGH --exit-code 1`):**

| Image | Result |
|---|---|
| `openclaw-playbook` | 0 CRITICAL/HIGH |
| `clawdbot-gateway` | 0 CRITICAL/HIGH |
| `clawdbot-agent` | 0 CRITICAL/HIGH |

`gateway` and `agent` had **never** been scanned — the job always died at `playbook`, which runs first. Both are now confirmed clean.

**Positive control — this is the result to trust.** The unmodified Dockerfile from `main` reproduces exactly the findings CI reported:

```
baseline-playbook: FINDINGS rc=1
    CVE-2025-47273  CVE-2026-45447  GHSA-6v7p-g79w-8964
```

Without it a green scan would be worthless. It mattered: one scan run *did* fail silently when Git Bash rewrote `--input /tars/x.tar` into `C:/Program Files/Git/tars/…`, so Trivy exited FATAL with `rc=1` — which a naive harness reads as "findings". The harness was rebuilt to disable MSYS path conversion and assert on output sentinels rather than exit codes.

**Hash verification, two-sided** (exact pip invocation, against `python:3.11-alpine3.22`):

| Case | Result |
|---|---|
| Committed lock | `Successfully installed PyYAML-6.0.3` — succeeds unaided |
| Digest of the wheel actually downloaded, one hex char flipped | `THESE PACKAGES DO NOT MATCH THE HASHES…`, rc=1 |
| `main`'s unpinned file | `ERROR: In --require-hashes mode…`, rc=1 — defect reproduced |

The middle case wrongly *passed* at first: pip accepts an artifact matching **any** listed digest, and I'd tampered an unrelated platform's wheel. Retargeted at `pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl`. That's a property of the lock, not a weakness — substitution would require matching one of 73 legitimate published digests. Separately, the musl wheel and sdist were downloaded from PyPI and re-hashed against the lock.

**Other checks:** all three images build `rc=0`; playbook smoke-run prints its usage banner; gateway `/health` on `127.0.0.1:8443` and agent `/health` on `127.0.0.1:8000` both return 0; `import pip`/`import setuptools` fail while `import yaml` succeeds in every production image. Immutable defaults intact (uid/gid 1000, non-root final `USER` on every stage, Alpine 3.22 pin). `actionlint` clean, no new `yamllint` findings. `pytest tests/` → 399 passed, 5 failed — **identical to clean `main`**, confirmed in a throwaway worktree.

## Note

The final commit (`chore:`) gitignores `ClaudeMemoryVault/` and `*.code-workspace`; it was already staged in the working tree and is unrelated to the scan fixes. Say the word and I'll split it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
