### PR TITLE
fix(C6-RT-09): pyproject pytest config makes the canonical `pytest -q` usable again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,10 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]  # FIX: C6-RT-09
+testpaths = ["tests"]  # FIX: C6-RT-09 - collect only the maintained suite, not gitignored tmp/claude-home* reference checkouts
+# Setting this ini key REPLACES pytest's built-in default list rather than extending it, so the
+# defaults are restated verbatim here and only "tmp" is added. Dropping them would silently
+# re-enable recursion into node_modules/venv/dot-dirs.  # FIX: C6-RT-09
+norecursedirs = ["*.egg", ".*", "_darcs", "build", "CVS", "dist", "node_modules", "venv", "{arch}", "tmp"]  # FIX: C6-RT-09 - pytest defaults + the local temp/reference checkout tree


### PR DESCRIPTION
## Finding

**C6-RT-09 — MEDIUM (test-harness).** Cycle 6 claim-veracity audit. Wave 0 enabler.
Files affected per the remediation plan: `pyproject.toml` only.

## The false claim

The repo documents `python -m pytest -q` as the canonical way to run the suite, but the
repository had **no pytest configuration at all** — no `[tool.pytest.ini_options]`, no
`pytest.ini`, no `[tool:pytest]` in `setup.cfg`, no `tox.ini`. With no `testpaths`, pytest
recurses from the repo root and walks into the gitignored local reference checkouts under
`tmp/claude-home-*/`.

That is not a cosmetic pollution problem. On `main`, the canonical command **aborts**:

```
!!!!!!!!!!!!!!!!!! Interrupted: 70 errors during collection !!!!!!!!!!!!!!!!!!!
1 warning, 70 errors in 12.22s
```

Every error is a third-party test module under `tmp/claude-home-*/reference/…`. The documented
entry point to the test suite is unusable, and an operator has to know to type an explicit path.

## What is provably true now

`[tool.pytest.ini_options]` sets `testpaths = ["tests"]`, so a bare invocation collects the
maintained suite and nothing else.

| command | on `main` | on this branch |
|---|---|---|
| `python -m pytest -q` | **70 collection errors, aborted** | **433 passed, 3 skipped** |
| `python -m pytest -q tests` | 433 passed, 3 skipped | 433 passed, 3 skipped |
| `python -m pytest --collect-only -q` | aborts | 436 collected, 0 from `tmp/` |

No test that runs today stops running: all 36 tracked test files live under `tests/`
(verified with `git ls-files`), so `testpaths` excludes nothing real.

## Verification

```bash
git switch fix/c6-rt-09-pytest-testpaths

# The claim: the canonical command now works
python -m pytest -q                       # 433 passed, 3 skipped

# Nothing outside tests/ is collected
python -m pytest --collect-only -q | grep -c '^tmp/'   # 0

# Config actually parses and takes effect
python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); print(d['tool']['pytest']['ini_options'])"

# Regression signal on main
git switch main && python -m pytest -q    # Interrupted: 70 errors during collection
```

## What the review found

**Fixed before opening — `norecursedirs` was silently disabling pytest's built-in defaults.**
The first draft set `norecursedirs = ["tmp", ".venv", ".tox", "build", "dist", "*.egg-info"]`.
Assigning that ini key **replaces** pytest's default list rather than extending it. Confirmed
against the installed pytest 9.0.2 (`_pytest/main.py:214-228`), whose default is:

```python
["*.egg", ".*", "_darcs", "build", "CVS", "dist", "node_modules", "venv", "{arch}"]
```

The draft therefore dropped `node_modules`, `venv`, `*.egg`, `_darcs`, `CVS`, `{arch}` and the
`.*` dot-directory pattern. That matters here — `security-scan.yml` already has an `npm ci` path
awaiting a `package.json`, so re-enabling recursion into `node_modules` was a live hazard. The
value now restates the defaults verbatim and appends only `tmp`; `.venv` and `.tox` are covered
by the restored `.*`, and `*.egg-info` was dropped as unreachable under `testpaths`.

**Also fixed:** added the trailing newline required by `.editorconfig` (`insert_final_newline = true`).

**Stated plainly: this is a no-op for CI.** All pytest jobs across the five workflows
(`compliance-check`, `detection-replay-validation`, `runtime-security-regression`, `security-scan`,
`lint`) invoke pytest against explicitly named `tests/security/*.py` paths, so nothing in CI
exercises the narrowed collection. The benefit is entirely to local and future invocations.

## Residual risk

Low. The change is additive configuration in a file with no prior pytest section, and it cannot
affect CI, which never relies on default collection.

One pre-existing issue is **not** addressed here (out of scope for this finding): the suite emits
`PytestUnknownMarkWarning: Unknown pytest.mark.integration` from
`tests/unit/test_compliance_reporter_iso27001.py:345`. Registering markers would be a natural
follow-up in this same config block, but it is a different change and is left for a separate
finding.
