### PR TITLE
fix(C6-RT-08): scan access --provider azure-ad reports checks it could not run as incomplete_data, not clean

### DIFF
--- a/src/clawdbot/scan_access.py
+++ b/src/clawdbot/scan_access.py
@@ -18,6 +18,12 @@ azure-ad
     Credentials are read from explicit keyword args or from environment
     variables: AZURE_AD_TENANT_ID, AZURE_AD_CLIENT_ID, AZURE_AD_CLIENT_SECRET.
 
+    NOT every rule above runs for this source.  The basic Graph user query
+    cannot supply the columns named in ``AZURE_AD_UNAVAILABLE_FIELDS``, so the
+    prod-access privilege-creep sub-rule and the orphaned-approver check are
+    reported as ``status="incomplete_data"`` rather than as a clean result.
+    See that constant for the authoritative list.
+
 SECURITY NOTE
 -------------
 Functions in this module that perform external I/O (``_graph_token``, ``_graph_get``,
@@ -132,6 +138,13 @@ def _graph_get(endpoint: str, token: str) -> dict[str, Any]:
     return resp.json()
 
 
+# FIX: C6-RT-08: the basic Microsoft Graph user query cannot supply these fields
+# (see load_azure_ad below — Systems/GrantedBy are hardcoded ""). Checks that depend
+# on them therefore did NOT run for the azure-ad source; they must be reported as
+# incomplete_data, never as a clean/zero result (which was false-clean evidence).
+AZURE_AD_UNAVAILABLE_FIELDS = frozenset({"Systems", "GrantedBy"})  # FIX: C6-RT-08
+
+
 @read_only_io
 def load_azure_ad(
     tenant_id: str | None = None,
@@ -200,6 +213,7 @@ def analyze_access(
     rows: list[dict[str, str]],
     *,
     days_threshold: int = 90,
+    unavailable_fields: frozenset[str] | None = None,  # FIX: C6-RT-08
 ) -> dict[str, list[dict[str, Any]]]:
     """Apply the access-review rules and return a findings dict.
 
@@ -207,7 +221,13 @@ def analyze_access(
       - inactive_users
       - privilege_creep
       - orphaned_approvers
+
+    ``unavailable_fields`` names columns the data source could not supply (e.g.
+    the azure-ad provider cannot populate Systems/GrantedBy). Checks that depend
+    on such a field are reported with an explicit ``status="incomplete_data"``
+    marker instead of silently returning no findings — see C6-RT-08.
     """
+    unavailable_fields = unavailable_fields or frozenset()  # FIX: C6-RT-08
     now = datetime.now(UTC)
     all_user_ids = {r.get("UserID", "").strip() for r in rows if r.get("UserID")}
 
@@ -280,6 +300,30 @@ def analyze_access(
                 "granted_by": granted_by,
                 "issue": "access approver (GrantedBy) not found in current user list",
             })
+
+    # FIX: C6-RT-08: when a required field was unavailable from the data source, the
+    # dependent check could not run. Emit an explicit incomplete_data marker so an
+    # empty finding list is never mistaken for "no risk found" (false-clean evidence).
+    if "Systems" in unavailable_fields:  # FIX: C6-RT-08
+        privilege_creep.append({  # FIX: C6-RT-08
+            "status": "incomplete_data",  # FIX: C6-RT-08
+            "check": "production_access_in_non_prod_role",  # FIX: C6-RT-08
+            "missing_fields": ["Systems"],  # FIX: C6-RT-08
+            "issue": (  # FIX: C6-RT-08
+                "production-access privilege-creep check could not run: "  # FIX: C6-RT-08
+                "'Systems' field unavailable from this data source"  # FIX: C6-RT-08
+            ),  # FIX: C6-RT-08
+        })  # FIX: C6-RT-08
+    if "GrantedBy" in unavailable_fields:  # FIX: C6-RT-08
+        orphaned_approvers.append({  # FIX: C6-RT-08
+            "status": "incomplete_data",  # FIX: C6-RT-08
+            "check": "orphaned_approver",  # FIX: C6-RT-08
+            "missing_fields": ["GrantedBy"],  # FIX: C6-RT-08
+            "issue": (  # FIX: C6-RT-08
+                "orphaned-approver check could not run: "  # FIX: C6-RT-08
+                "'GrantedBy' field unavailable from this data source"  # FIX: C6-RT-08
+            ),  # FIX: C6-RT-08
+        })  # FIX: C6-RT-08
 
     return {
         "inactive_users": inactive_users,
@@ -356,19 +400,45 @@ def run_access_review(
             client_secret=client_secret,
         )
 
-    findings = analyze_access(rows, days_threshold=days_threshold)
+    # FIX: C6-RT-08: declare which required fields the source cannot supply, so
+    # analyze_access reports dependent checks as incomplete rather than clean.
+    unavailable_fields = (  # FIX: C6-RT-08
+        AZURE_AD_UNAVAILABLE_FIELDS if input_source == "azure-ad" else frozenset()  # FIX: C6-RT-08
+    )  # FIX: C6-RT-08
+
+    findings = analyze_access(  # FIX: C6-RT-08
+        rows,
+        days_threshold=days_threshold,
+        unavailable_fields=unavailable_fields,  # FIX: C6-RT-08
+    )
+
+    # FIX: C6-RT-08: count real findings separately from incomplete_data markers so a
+    # check that could not run never inflates a real-finding count nor reads as zero.
+    real_inactive = [f for f in findings["inactive_users"] if f.get("status") != "incomplete_data"]  # FIX: C6-RT-08
+    real_creep = [f for f in findings["privilege_creep"] if f.get("status") != "incomplete_data"]  # FIX: C6-RT-08
+    real_orphaned = [f for f in findings["orphaned_approvers"] if f.get("status") != "incomplete_data"]  # FIX: C6-RT-08
+    incomplete_data_count = sum(  # FIX: C6-RT-08
+        1 for cat in findings.values() for f in cat if f.get("status") == "incomplete_data"  # FIX: C6-RT-08
+    )  # FIX: C6-RT-08
 
     summary = {
         "total_users": len(rows),
-        "inactive_count": len(findings["inactive_users"]),
-        "privilege_creep_count": len(findings["privilege_creep"]),
-        "orphaned_approver_count": len(findings["orphaned_approvers"]),
+        "inactive_count": len(real_inactive),  # FIX: C6-RT-08
+        "privilege_creep_count": len(real_creep),  # FIX: C6-RT-08
+        "orphaned_approver_count": len(real_orphaned),  # FIX: C6-RT-08
+        "incomplete_data_count": incomplete_data_count,  # FIX: C6-RT-08
     }
 
     # Derive simple compliance signals (warn if any findings)
+    # FIX: C6-RT-08: when a required field was unavailable, the access-rights review
+    # (ISO 27001 A.9.2.5) could not fully run -> report "incomplete", never "pass".
     compliance = {
         "soc2_cc6_1": "warn" if summary["inactive_count"] > 0 else "pass",
-        "iso27001_a9_2_5": "warn" if summary["privilege_creep_count"] > 0 else "pass",
+        "iso27001_a9_2_5": (  # FIX: C6-RT-08
+            "incomplete" if unavailable_fields & {"Systems", "GrantedBy"}  # FIX: C6-RT-08
+            else "warn" if summary["privilege_creep_count"] > 0  # FIX: C6-RT-08
+            else "pass"  # FIX: C6-RT-08
+        ),
     }
 
     result: dict[str, Any] = {
@@ -393,10 +463,10 @@ def run_access_review(
             ["user_id", "email", "role", "last_login", "days_inactive", "recommendation"],
         )
 
-    if output_privilege_creep_csv and findings["privilege_creep"]:
+    if output_privilege_creep_csv and real_creep:  # FIX: C6-RT-08: export real findings only — never the incomplete_data marker (no identity fields)
         _write_findings_csv(
             output_privilege_creep_csv,
-            findings["privilege_creep"],
+            real_creep,  # FIX: C6-RT-08: markers excluded so the CSV artifact can't read as an empty-identity finding
             ["user_id", "email", "issue"],
         )
 

--- a/tests/security/test_vulnerability_scanning.py
+++ b/tests/security/test_vulnerability_scanning.py
@@ -372,6 +372,104 @@ class TestJiraTicketCreation:
 
 
 # ---------------------------------------------------------------------------
+# C6-RT-08: the azure-ad source cannot supply Systems/GrantedBy, so the
+# privilege-creep (prod-access) and orphaned-approver checks must report
+# incomplete_data instead of silently producing false-clean evidence. The CSV
+# path (all fields present) must be byte-stable.
+# Compliance: SOC 2 CC6.1, ISO 27001 A.9.2.5
+# ---------------------------------------------------------------------------
+
+class TestAccessReviewIncompleteData:
+    """C6-RT-08 — incomplete-data reporting for sources missing required fields."""
+
+    def _azure_rows(self):
+        """Rows as load_azure_ad() would emit: Systems/GrantedBy hardcoded empty."""
+        recent = (datetime.now(UTC) - timedelta(days=5)).strftime("%Y-%m-%d")
+        return [
+            {  # privilege creep detectable from Role alone (Admin+Developer)
+                "UserID": "az1", "Name": "Admin Dev", "Email": "ad@corp.com",
+                "Role": "Admin,Developer", "Systems": "", "LastLogin": recent,
+                "GrantedDate": "2024-01-01", "GrantedBy": "", "_source": "azure_ad",
+            },
+            {  # inactive detectable from empty LastLogin
+                "UserID": "az2", "Name": "Viewer", "Email": "v@corp.com",
+                "Role": "Viewer", "Systems": "", "LastLogin": "",
+                "GrantedDate": "2024-02-01", "GrantedBy": "", "_source": "azure_ad",
+            },
+        ]
+
+    def test_csv_path_is_byte_stable_with_no_markers(self, sample_access_rows):
+        """CSV input (all fields present) yields the SAME finding lists, no incomplete_data."""
+        findings = analyze_access(sample_access_rows, days_threshold=90)
+        # Pre-fix counts: 1 inactive (u002), 2 privilege creep (u001 admin+dev, u003 prod), 2 orphaned (u001, u003).
+        assert len(findings["inactive_users"]) == 1
+        assert len(findings["privilege_creep"]) == 2
+        assert len(findings["orphaned_approvers"]) == 2
+        # No incomplete_data markers must leak into the CSV path.
+        for cat in findings.values():
+            assert all(f.get("status") != "incomplete_data" for f in cat)
+
+    def test_azure_unavailable_fields_emit_incomplete_markers(self):
+        """Systems/GrantedBy unavailable -> the dependent checks carry incomplete_data."""
+        findings = analyze_access(
+            self._azure_rows(),
+            days_threshold=90,
+            unavailable_fields=scan_access_mod.AZURE_AD_UNAVAILABLE_FIELDS,
+        )
+        creep_markers = [f for f in findings["privilege_creep"] if f.get("status") == "incomplete_data"]
+        orphan_markers = [f for f in findings["orphaned_approvers"] if f.get("status") == "incomplete_data"]
+        assert len(creep_markers) == 1
+        assert creep_markers[0]["missing_fields"] == ["Systems"]
+        assert len(orphan_markers) == 1
+        assert orphan_markers[0]["missing_fields"] == ["GrantedBy"]
+        # The Role-based privilege-creep sub-rule still works (real finding survives).
+        real_creep = [f for f in findings["privilege_creep"] if f.get("status") != "incomplete_data"]
+        assert any("admin" in " ".join(f.get("roles", [])).lower() for f in real_creep)
+
+    def test_run_access_review_azure_is_not_false_clean(self, monkeypatch):
+        """End-to-end azure path: counts honest, compliance 'incomplete' — never false-clean."""
+        monkeypatch.setattr(scan_access_mod, "load_azure_ad", lambda **kw: self._azure_rows())
+        result = run_access_review(provider="azure-ad", days_threshold=90)
+        summary = result["summary"]
+        # incomplete_data is surfaced; markers do NOT inflate real-finding counts.
+        assert summary["incomplete_data_count"] == 2
+        assert summary["privilege_creep_count"] == 1     # admin+dev real finding only
+        assert summary["orphaned_approver_count"] == 0    # marker excluded from the real count
+        # The core fix: privilege-creep compliance is NOT reported clean when data is missing.
+        assert result["compliance"]["iso27001_a9_2_5"] == "incomplete"
+
+    def test_azure_privilege_creep_csv_export_excludes_markers(self, monkeypatch, tmp_path):
+        """The --output-privilege-creep-csv artifact must not serialize the incomplete_data marker."""
+        monkeypatch.setattr(scan_access_mod, "load_azure_ad", lambda **kw: self._azure_rows())
+        creep_csv = tmp_path / "creep.csv"
+        run_access_review(
+            provider="azure-ad",
+            days_threshold=90,
+            output_privilege_creep_csv=str(creep_csv),
+        )
+        assert creep_csv.exists()
+        lines = [ln for ln in creep_csv.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        # Header + exactly one real finding (az1 admin+dev); no empty-identity marker row.
+        assert len(lines) == 2, lines
+        assert "az1" in lines[1]
+        assert "incomplete_data" not in creep_csv.read_text(encoding="utf-8")
+        assert "could not run" not in creep_csv.read_text(encoding="utf-8")
+
+    def test_run_access_review_csv_summary_is_additive(self, monkeypatch, sample_access_rows):
+        """CSV path: new incomplete_data_count==0; compliance values unchanged (warn/pass)."""
+        monkeypatch.setattr(scan_access_mod, "load_csv", lambda _p: sample_access_rows)
+        result = run_access_review(input_csv="dummy.csv", days_threshold=90)
+        summary = result["summary"]
+        assert summary["incomplete_data_count"] == 0
+        assert summary["privilege_creep_count"] == 2
+        assert summary["inactive_count"] == 1
+        assert summary["orphaned_approver_count"] == 2
+        # No "incomplete" status on the CSV path; existing warn/pass semantics preserved.
+        assert result["compliance"]["iso27001_a9_2_5"] == "warn"
+        assert result["compliance"]["soc2_cc6_1"] == "warn"
+
+
+# ---------------------------------------------------------------------------
 # TestAutoRemediation → repurposed as TestScanStrictModeAndArtifacts
 # Tests scan behavior under strict mode and artifact persistence.
 # Compliance: SOC 2 CC7.2, ISO 27001 A.12.6.1


### PR DESCRIPTION
## Finding

**C6-RT-08 — HIGH (product-runtime).** Cycle 6 claim-veracity audit.
Files affected per the remediation plan: `src/clawdbot/scan_access.py` + its test.

## The false claim

`load_azure_ad()` builds its rows from a basic Microsoft Graph user query and hardcodes
`Systems = ""` and `GrantedBy = ""` (`src/clawdbot/scan_access.py:184,187`). Two access-review
rules read exactly those fields:

- the **production-access** sub-rule of privilege-creep (reads `Systems`)
- the **orphaned-approver** check (reads `GrantedBy`)

With both fields permanently empty, neither check could ever fire on the `azure-ad` path. They
returned empty lists, which `run_access_review` serialized as `privilege_creep_count: 0` and
`orphaned_approver_count: 0`, and which the compliance block reported as
`iso27001_a9_2_5: "pass"`.

That is false-clean evidence: a check that **did not run** was indistinguishable in the artifact
from a check that **ran and found nothing**.

## What is provably true now

- `analyze_access()` takes an explicit `unavailable_fields` argument, defaulting to `frozenset()`
  — the CSV path is untouched. `run_access_review()` passes
  `AZURE_AD_UNAVAILABLE_FIELDS = frozenset({"Systems", "GrantedBy"})` when the source is `azure-ad`.
- Each dependent check whose field is unavailable emits an explicit marker
  `{"status": "incomplete_data", "check": …, "missing_fields": […], "issue": "…could not run…"}`
  instead of contributing silence.
- Markers are counted separately from real findings. `summary.incomplete_data_count` is new;
  `inactive_count` / `privilege_creep_count` / `orphaned_approver_count` count real findings only,
  so a marker can neither inflate a real count nor pass for one.
- `compliance.iso27001_a9_2_5` reports `"incomplete"` — never `"pass"` — on any run where a
  required field was unavailable.
- CSV artifacts keep their shape: the privilege-creep export receives real findings only, so an
  identity-less marker is never serialized into a `[user_id, email, issue]` row.
- The module docstring no longer advertises privilege-creep and orphaned-approver detection as
  unconditional for every source; it names `AZURE_AD_UNAVAILABLE_FIELDS` so doc and code cannot drift.

Scope of that claim: it is proven **at the `scan access` JSON boundary**. It is not yet true of
every downstream consumer — see Residual risk, which is the important part of this PR.

## Verification

```bash
git switch fix/c6-rt-08-azure-incomplete-data

# New coverage
python -m pytest tests/security/test_vulnerability_scanning.py::TestAccessReviewIncompleteData -q

# Surrounding suites
python -m pytest tests/security/test_vulnerability_scanning.py tests/unit/test_scan_access_cli.py \
                tests/security/test_scan_access_security.py -q     # 42 passed, 2 skipped

# Full suite: 438 passed, 3 skipped (main baseline is 433 passed, 3 skipped; +5 new tests)
python -m pytest -q tests
```

Direct payload inspection — the marker is the whole point, so look at it:

```bash
python -c "import json; from clawdbot.scan_access import analyze_access, AZURE_AD_UNAVAILABLE_FIELDS; \
rows=[{'UserID':'u1','Name':'A','Email':'a@example.com','Role':'Analyst','Systems':'', \
'LastLogin':'2026-08-01','GrantedDate':'2026-01-01','GrantedBy':''}]; \
print(json.dumps(analyze_access(rows, unavailable_fields=AZURE_AD_UNAVAILABLE_FIELDS), indent=2))"
# expect one status=incomplete_data entry under privilege_creep and one under orphaned_approvers
```

**Be honest about the regression signal.** Running the new tests against `main` gives 3 failed /
2 passed, but those three are **API-shape** failures (`AttributeError: AZURE_AD_UNAVAILABLE_FIELDS`,
`KeyError: 'incomplete_data_count'`) — not assertions that main computed a wrong value. The
false-clean behaviour on main is demonstrated by inspecting the payload, not by a red test.

## What the review found

This branch went through a multi-reviewer adversarial review before opening. Findings that
survived refutation are recorded here rather than quietly dropped.

**Refuted (documented as deliberate design, no change made):**

- *"`incomplete` overrides a real `warn`"* — the ternary returns `incomplete` for every azure-ad
  run, including ones with real privilege-creep findings. Refuted: no consumer filters on the
  literal string `"warn"`, `privilege_creep_count` still carries the real finding, and the CLI
  renders `INCOMPLETE` non-green. Worth knowing the behaviour exists.
- *"no test covers the zero-real-finding azure case"* — refuted by reproduction: that case does
  emit both markers with `incomplete_data_count: 2`, and the absent-CSV behaviour is unchanged
  from main.

**Confirmed, and deliberately NOT fixed here (Rule 1 — outside this finding's Files affected):**
see Residual risk.

## Residual risk

**This PR does not close the false-clean class end-to-end.** Three gaps are known and tracked
separately rather than silently folded in:

1. **The weekly report still reads clean.** `src/clawdbot/report_weekly.py:108-111`
   `_overall_status()` inspects only `inactive_count` and `privilege_creep_count`. It ignores the
   new `incomplete_data_count` and the access `compliance` dict entirely, and `_render_pdf`
   renders no access section. So `report weekly --access-scan access.json --pdf-report out.pdf`
   still prints **`Overall Status: HEALTHY`** for an azure review in which two of three checks
   never ran. This is *not a regression* — it is unchanged from pre-fix — but it means the
   audit-facing artifact still presents the tenant as healthy. Also `tools/openclaw-cli.py:751-766`
   never prints `incomplete_data_count`.
2. **`Role` on the azure-ad path is a job title, not an entitlement.** `load_azure_ad()` maps
   `"Role": u.get("jobTitle", "")`, and the Graph `$select` requests no `/directoryRoles`,
   `appRoleAssignments` or group memberships. `analyze_access` splits `Role` on commas and requires
   both `admin` and `developer` — which a real free-text `jobTitle` will essentially never satisfy.
   So the *surviving* privilege-creep sub-rule also cannot meaningfully fire on azure-ad, while
   still reporting a zero that looks trustworthy. This is a **semantic** defect (field populated,
   wrong meaning), distinct from the **unavailable-field** defect this PR fixes, which is why it is
   not folded in. Note the new test fixture sets `Role: "Admin,Developer"`, which exercises a
   capability the real provider will not produce.
3. **The privilege-creep CSV is not written at all when there is no real finding.** Unchanged from
   main, but it means a pipeline doing `test -s creep.csv || echo "no privilege creep"` still draws
   a clean conclusion from a check that never ran.

Gaps 1-3 are recorded as candidate findings **C6-RT-20**, **C6-RT-19** and (within 1)
the CLI surfacing item, in the local remediation plan. Do not sign C6-RT-08 off as closing the
false-clean class until at least C6-RT-20 lands.
