### PR TITLE
fix(C6-RT-11): restore-origin driver reports a failed source as an attributable error

### DIFF
--- a/tests/integration/test_skill_restore_origin.py
+++ b/tests/integration/test_skill_restore_origin.py
@@ -79,6 +79,10 @@ mkdir -p "$SB/logs" "$SB/q" "$SB/origins" "$SB/skills"
 # so no sed-based suppression is needed.
 # shellcheck disable=SC1090
 source "$SCRIPT"
+## FIX: C6-RT-11: pin "driver failed to source the script" (restore_skill undefined) as a loud,
+## attributable error instead of a downstream "restore_skill: command not found" — distinguishes
+## that failure mode from path-mangling. Runs before `set +e`; the `||` keeps errexit from aborting.
+declare -f restore_skill >/dev/null 2>&1 || { echo "DRIVER_ERROR: restore_skill undefined after sourcing $SCRIPT (scenario=$SCEN)" >&2; exit 4; }  ## FIX: C6-RT-11
 # errexit OFF: restore_skill returns non-zero on every rejection path and we capture $?
 # (with -e on, `restore_skill ...; echo "RC=$?"` would abort before the echo). nounset and
 # pipefail stay ON so unset-var bugs and pipe failures in the driver surface attributably.


### PR DESCRIPTION
## Finding

**C6-RT-11 — MEDIUM (test-harness / platform).** Cycle 6 claim-veracity audit.
Files affected per the remediation plan: `tests/integration/test_skill_restore_origin.py` only.

**Important framing:** the remediation plan records C6-RT-11 as **DOES NOT REPRODUCE**. There is
no observed failure to fix. What ships here is a small diagnostic improvement, and — more
importantly — the deliberate *removal* of a change that would have made the suite quieter.

## What changed

One line in the bash driver. After sourcing `skill_integrity_monitor.sh`, the driver now asserts
that `restore_skill` was actually defined:

```bash
declare -f restore_skill >/dev/null 2>&1 || { echo "DRIVER_ERROR: restore_skill undefined after sourcing $SCRIPT (scenario=$SCEN)" >&2; exit 4; }
```

Previously a failed `source` surfaced only as a downstream `restore_skill: command not found`,
which is indistinguishable from path mangling — the exact confusion C6-RT-11 was filed about.
The guard runs before `set +e`; the `||` keeps `errexit` from aborting; `exit 4` collides with no
return code any test asserts on, and no test matches on exact stderr.

## What was removed during review, and why

An earlier draft of this fix added a collection-time preflight (`_bash_can_resolve_paths`) that
spawned bash to check whether a `_to_bash_path`-converted temp dir was visible, plus a second
module-level `pytest.mark.skipif` keyed off it. **That was dropped**, and it is worth recording why,
because it is the repo's documented anti-pattern:

1. The preflight caught `(OSError, subprocess.SubprocessError)` and returned `False` for *any*
   exception. `subprocess.TimeoutExpired` **is** a `subprocess.SubprocessError` subclass
   (`issubclass(...) is True`), so a slow spawn against the 5s budget — a loaded Windows host, an
   AV scan, a cold CI runner — silently flipped the flag. So did a blocked spawn (`OSError`) and a
   Windows `TemporaryDirectory.__exit__` cleanup `PermissionError`.
2. Flipping that flag skipped **all 8** `restore_skill` regression tests: tamper-rejection,
   fail-closed untracked restore, symlink-parent rejection, path-traversal and invalid-id
   rejection — the C6-M-17 / issue #123 controls.
3. The skip reason would have read *"detected bash flavor cannot resolve … sandbox paths"*, a
   statement that is false in every one of those cases.
4. Nothing would have caught it. There is no `conftest.py` in the repo, no `-rs`, and **no CI
   workflow collects `tests/integration/` at all** — all five workflows invoke pytest against
   explicitly named `tests/security/*.py` files. The skip would have read as a clean exit 0.

Trading a loud failure for a silent green, to guard against a condition the plan records as
non-reproducing, is a net negative. The repo already has the opposite precedent in
`scripts/verification/validate_detection_replay.py:271-279` (C5-M-01): an unavailable capability
is a non-pass unless the operator explicitly opts out.

The single pre-existing `skipif(_BASH_PATH is None)` is unchanged.

## Verification

```bash
git switch fix/c6-rt-11-restore-origin-bash-flavor

python -m pytest tests/integration/test_skill_restore_origin.py -q -rs
# 7 passed, 1 skipped
# the 1 skip is pre-existing and platform-legitimate:
#   "platform cannot create resolvable symlinks" (Windows without Developer Mode)

python -m pytest -q tests     # full suite, unchanged from main
python -m ruff check tests/integration/test_skill_restore_origin.py
```

Confirm no skip was added — the count must still be exactly 1, and its reason must be the symlink
one. If you see 8 skipped, something reintroduced a module-level skip.

## Residual risk

Very low; the diff is 4 added lines in a bash heredoc, in a test-only file, with no production
code touched.

Two things this PR deliberately does **not** do:

- It does not add a use-time bash-visibility assertion inside `_run()`. That was the reviewer's
  suggested alternative to the removed preflight (fail loudly at the point of use rather than skip
  at collection). It is a reasonable follow-up, but it would add a subprocess per test to diagnose
  a condition nobody has observed, so it is left out.
- It does not fix the fact that **CI never runs this module at all**. That is a real coverage gap —
  these are security regression tests for tamper-rejection and path traversal that only ever run on
  a developer's machine — but it needs a workflow change, which is outside this finding's
  Files-affected list (Rule 1). Recorded as a separate candidate finding.
