### PR TITLE
fix(C6-RT-22): compliance-check now actually triggers on the code its test suite covers

### DIFF
--- a/.github/workflows/compliance-check.yml
+++ b/.github/workflows/compliance-check.yml
@@ -11,6 +11,11 @@ on:
       - "configs/organization-policies/**"
       - "tools/compliance-reporter.py" # FIX: C6-M-??
       - "tools/compliance-data/**" # FIX: C6-M-??
+      - "tests/security/**" # FIX: C6-RT-22
+      - "src/clawdbot/**" # FIX: C6-RT-22
+      - "tools/policy-validator.py" # FIX: C6-RT-22: run by 4 steps + exec_module'd by test_policy_compliance.py
+      - "requirements.txt" # FIX: C6-RT-22: installed by every job in this workflow
+      - "pyproject.toml" # FIX: C6-RT-22: `pip install -e .` makes src/clawdbot importable for the test suite
       - ".github/workflows/compliance-check.yml" # FIX: C6-M-??
   workflow_dispatch:
 

--- a/.github/workflows/runtime-security-regression.yml
+++ b/.github/workflows/runtime-security-regression.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - 'scripts/verification/**'
       - 'configs/examples/docker-compose-full-stack.yml'
-      - 'tests/security/**'
+      - 'tests/security/test_runtime_security_regression.py' # FIX: C6-RT-22
       - '.github/workflows/runtime-security-regression.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
Closes #141

`compliance-check.yml` holds the only pytest invocation in CI that runs the policy-compliance and vulnerability/access-review suites, but its `on.pull_request.paths` filter reached none of the code those suites exercise. **Editing the code under test could not trigger the job that tests it**, so a PR displayed green from `lint` alone. This is a recurrence of #87.

### Filter reconciled with what the jobs actually run
| Added path | Why |
|---|---|
| `tests/security/**` | the two pytest targets themselves |
| `src/clawdbot/**` | imported by `test_vulnerability_scanning.py` |
| `tools/policy-validator.py` | run by four steps, and `exec_module`'d by `test_policy_compliance.py` |
| `requirements.txt`, `pyproject.toml` | installed by every job; `pip install -e .` is what makes `src/clawdbot` importable |

### runtime-security-regression.yml narrowed
Its trigger was the misleadingly broad `tests/security/**` while it runs a single file. That breadth made a PR touching any security test look covered when it was not. Narrowing loses no coverage: the job's other steps use `scripts/verification/**` and `configs/examples/docker-compose-full-stack.yml`, both still in the filter, and `tests/security/**` coverage now lives with the workflow that really runs it. Widening what it runs was rejected — it would duplicate compliance-check's suite for no new signal.

### Invariant restored
For every workflow, every path referenced by a job's `pytest <file>` argument, and the source tree that file imports, is reachable by that workflow's trigger filter.

### Verification
`actionlint` exit 0. `yamllint` reports no new findings versus the pre-change baseline. No pytest command, `permissions:` block, threshold or `workflow_dispatch` trigger changed. Adding paths cannot duplicate runs — `paths` is an OR-list and fires one run regardless of how many patterns match.

AC2 ("a PR touching only `src/clawdbot/**` shows Compliance Check") is only observable once this is on `main`; the RT-19/RT-20 PRs are the natural proof.