### PR TITLE
fix(C6-RT-21): CI now actually runs the restore_skill origin-ledger regression tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,151 @@
+# C6-RT-21 — tests/integration/ was collected by NO CI workflow, so the
+# origin-ledger regression suite for restore_skill (C6-M-17 / issue #123) only
+# ever ran on a developer machine.  This workflow runs the whole directory on
+# the GitHub-hosted runner and fails if any test is skipped rather than run.
+name: Integration Tests # FIX: C6-RT-21
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # FIX: C6-RT-21
+
+on:
+  pull_request:
+    # The pytest target below is the WHOLE tests/integration/ tree, so this
+    # filter must reach every tree those modules import or shell out to.
+    # Each entry is derived from a real reference in tests/integration/*.py.
+    paths:
+      - 'tests/integration/**' # FIX: C6-RT-21
+      - 'tests/fixtures/**' # FIX: C6-RT-21
+      - 'src/**' # FIX: C6-RT-21
+      - 'scripts/supply-chain/**' # FIX: C6-RT-21
+      - 'scripts/incident-response/**' # FIX: C6-RT-21
+      - 'examples/security-controls/**' # FIX: C6-RT-21
+      - 'tools/compliance-reporter.py' # FIX: C6-RT-21
+      - 'configs/organization-policies/**' # FIX: C6-RT-21
+      - 'requirements.txt' # FIX: C6-RT-21
+      - 'pyproject.toml' # FIX: C6-RT-21
+      - 'setup.py' # FIX: C6-RT-21
+      - '.github/workflows/integration-tests.yml' # FIX: C6-RT-21
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  integration-tests:
+    name: Integration Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # requirements.txt: boto3 / PyYAML / psutil / jinja2 / networkx are imported
+      # (or patched) by the incident-response and backup tests.
+      # `pip install -e .`: test_cycle5_claim_regressions.py imports
+      # `clawdbot.scan_vulnerability` at MODULE level — without the editable
+      # install that is a collection error, not a skip.
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+          pip install pytest
+
+      # Whole-directory target, deliberately: it keeps the `tests/integration/**`
+      # trigger honest — the path filter and the pytest target cover the same set.
+      # The two --deselect'd cases are gated on `sys.platform == "win32"` inside
+      # test_cycle5_claim_regressions.py (they invoke .venv/Scripts/pip-audit.exe),
+      # so on ubuntu-latest they can only ever report as skips. They are excluded
+      # explicitly here rather than silently tolerated by the gate below.
+      - name: Run integration tests
+        env:
+          JUNIT_XML: ${{ runner.temp }}/integration-evidence/junit.xml # FIX: C6-RT-21
+        run: |
+          mkdir -p "$(dirname "$JUNIT_XML")"
+          WIN_ONLY='tests/integration/test_cycle5_claim_regressions.py::TestDependencyAuditShClaim'
+          pytest tests/integration/ -rs --junit-xml="$JUNIT_XML" -v \
+            --deselect "$WIN_ONLY::test_dependency_audit_sh_claim_exits_0_on_clean_requirements" \
+            --deselect "$WIN_ONLY::test_dependency_audit_sh_claim_exits_1_for_seeded_cve_fixture"
+
+      # THE SKIP GATE. A green job must mean "the tests ran", not "the tests were
+      # collected". Runs even when pytest failed so the skip list is always visible.
+      - name: Enforce zero-skip / minimum-collected gate
+        if: always()
+        env:
+          JUNIT_XML: ${{ runner.temp }}/integration-evidence/junit.xml # FIX: C6-RT-21
+        run: |
+          python - <<'PY'
+          import os
+          import sys
+          import xml.etree.ElementTree as ET
+          from pathlib import Path
+
+          # Floor, not equality: tests/integration/ collects 138 today, minus the 2
+          # win32-only pip-audit cases deselected above = 136. A growing suite still
+          # passes; a suite that silently loses tests (renamed file dropped from
+          # collection, import guard swallowing a module) fails and needs a human
+          # to re-justify the number.
+          EXPECTED_MIN_TESTS = 136
+
+          report = Path(os.environ["JUNIT_XML"])
+          if not report.is_file():
+              print(f"GATE FAIL: {report} was not produced - the test step did not run.")
+              sys.exit(1)
+
+          root = ET.parse(report).getroot()
+          suites = [root] if root.tag == "testsuite" else list(root.iter("testsuite"))
+          total = sum(int(s.get("tests", "0")) for s in suites)
+          errors = sum(int(s.get("errors", "0")) for s in suites)
+          failures = sum(int(s.get("failures", "0")) for s in suites)
+
+          skipped = []
+          for case in root.iter("testcase"):
+              for node in case.findall("skipped"):
+                  name = f"{case.get('classname', '')}::{case.get('name', '')}"
+                  skipped.append((name, (node.get("message") or "").strip()))
+
+          print(
+              f"junit summary: ran={total} failures={failures} "
+              f"errors={errors} skipped={len(skipped)}"
+          )
+
+          ok = True
+          if skipped:
+              print(f"GATE FAIL: {len(skipped)} test(s) SKIPPED; a green job must mean they ran:")
+              for name, reason in skipped:
+                  print(f"  SKIPPED {name}")
+                  print(f"          reason: {reason}")
+              ok = False
+          if total < EXPECTED_MIN_TESTS:
+              print(
+                  f"GATE FAIL: only {total} test(s) ran, expected at least "
+                  f"{EXPECTED_MIN_TESTS} - tests disappeared from collection."
+              )
+              ok = False
+          if errors:
+              print(f"GATE FAIL: {errors} collection/setup error(s) in the junit report.")
+              ok = False
+          # Without this the gate printed "GATE PASS" on a run with failing tests.
+          # The job was still red (the pytest step has no continue-on-error), but a
+          # log line reading PASS next to a red job is exactly the ambiguity this
+          # workflow exists to remove.
+          if failures:
+              print(f"GATE FAIL: {failures} test failure(s) in the junit report.")
+              ok = False
+
+          if ok:
+              print(f"GATE PASS: {total} test(s) ran, 0 skipped, 0 failed.")
+          sys.exit(0 if ok else 1)
+          PY
+
+      - name: Upload integration test evidence
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: integration-test-evidence
+          path: ${{ runner.temp }}/integration-evidence
+          retention-days: 90


### PR DESCRIPTION
Closes #140

`tests/integration/` was collected by **no** CI workflow. All five workflows invoke pytest against explicitly named `tests/security/*.py` files, so the eight origin-ledger regression tests guarding the C6-M-17 / #123 hardening of `restore_skill` — tamper rejection, fail-closed untracked restore, symlink-parent rejection, path traversal and invalid-id rejection — only ever ran on a developer's machine. With no `conftest.py` and no `-rs` anywhere, a silent skip read as a clean exit 0.

That was not hypothetical: PR #137 originally carried a collection-time preflight that would have skipped all eight tests on any transient subprocess failure, and nothing in CI would have noticed.

### Design
- Runs the **whole** `tests/integration/` tree, deliberately, so the pytest target and the `tests/integration/**` trigger cover the same set rather than repeating the trigger-vs-target mismatch this wave is fixing.
- Trigger paths derived from real references in `tests/integration/*.py`, so every tree those modules import or shell out to can reach the job.
- `-rs` so any skip prints its reason.
- **The skip gate:** a junit-parsing step (stdlib only, no new dependencies) that fails the job on any skip, any collection/setup error, any test failure, and if the collected count falls below a floor of 136. A green job therefore means *the tests ran*, not *the tests were collected*.
- Two win32-only pip-audit cases are deselected explicitly rather than silently tolerated by the gate; they invoke `.venv/Scripts/pip-audit.exe` and can only ever report as skips on ubuntu-latest.
- `permissions: contents: read` only. No external provider, webhook or remote callback (Sisyphus Audit Rule 5).

### Verification
Local: `pytest tests/integration/ -q -rs` gives 137 passed, 1 skipped on Windows (the symlink test, which should run on Linux). The gate was driven against synthetic junit reports and fails closed on skips, on a shrinking suite, on errors, and on a missing XML. `actionlint` exit 0; `yamllint` clean.

Expected first Linux result is **136 passed, 0 skipped**. Per AC5 that number is recorded here once the job has actually run — the gate is strict by design, so this is the run that proves it.

---

## AC5 — recorded Linux result (green)

[Run 31493765787](https://github.com/topazyo/openclaw-security-playbook/actions/runs/31493765787/job/93786290397), after #150 (C6-RT-25) and #151 (C6-RT-24) landed on `main`:

```
tests/integration/test_skill_restore_origin.py::test_symlink_swapped_parent_is_rejected PASSED
junit summary: ran=136 failures=0 errors=0 skipped=0
GATE PASS: 136 test(s) ran, 0 skipped, 0 failed.
```

**136 passed, 0 skipped** — matching the prediction, with the symlink test running (not skipped) on Linux.

### What this job found on its first run, and why that is the point

The initial run was `ran=136 failures=8 errors=0 skipped=0` → `GATE FAIL`. Nothing was weakened to get to green; the two defects it exposed were filed and fixed first:

- **#147 / C6-RT-24** — seven forensics tests ignored their `tmp_path` and wrote to `/var/lib/openclaw/forensics`, passing on Windows only by polluting the developer's disk.
- **#148 / C6-RT-25** — `restore_skill`'s tamper check compared a canonicalized path against a raw one, misattributing a swapped parent symlink as `reason=tamper` and making the `parent_symlink` guard unreachable. That test is `skipif`-guarded on Windows and had **never executed anywhere** before this workflow ran it.

A CI job added because "these security tests never run" immediately caught two real defects, one of them in the security control it was written to protect. No test was modified to accommodate CI and the zero-skip gate was never relaxed.
