### PR TITLE
fix(C6-RT-20): weekly report no longer reports HEALTHY for an access review whose checks could not run

### DIFF
--- a/src/clawdbot/report_weekly.py
+++ b/src/clawdbot/report_weekly.py
@@ -86,12 +86,107 @@ def _load_optional_json(path: str | None, label: str) -> dict[str, Any] | None:
         return {"error": f"could not load {label}: {exc}"}
 
 
+#: Findings categories emitted by ``scan access`` that may carry
+#: ``incomplete_data`` markers interleaved with real findings.
+_ACCESS_FINDING_CATEGORIES = (  # FIX: C6-RT-20
+    "inactive_users",  # FIX: C6-RT-20
+    "privilege_creep",  # FIX: C6-RT-20
+    "orphaned_approvers",  # FIX: C6-RT-20
+)  # FIX: C6-RT-20
+
+
+def _access_incomplete_checks(access: dict[str, Any] | None) -> list[str]:  # FIX: C6-RT-20
+    """Return one human-readable line per access check that COULD NOT RUN.
+
+    The ``scan access`` producer interleaves ``incomplete_data`` marker dicts of
+    the shape::
+
+        {"status": "incomplete_data",
+         "check": "production_access_in_non_prod_role",
+         "missing_fields": ["Systems"],
+         "issue": "... could not run: 'Systems' field unavailable ..."}
+
+    with real findings inside each category list.  Real findings never carry a
+    ``status`` key, so markers are detected with
+    ``f.get("status") == "incomplete_data"``.
+
+    Returns an empty list for an artifact produced before the marker schema
+    existed (no markers, no ``incomplete_data_count``); the caller falls back to
+    a count-based message in that case.  Never raises on a missing key.
+    """
+    if not isinstance(access, dict):  # FIX: C6-RT-20
+        return []  # FIX: C6-RT-20
+
+    # Markers may live at the top level or nested under a "findings" mapping;
+    # accept either layout so the consumer is not coupled to one nesting.
+    containers: list[dict[str, Any]] = [access]  # FIX: C6-RT-20
+    nested = access.get("findings")  # FIX: C6-RT-20
+    if isinstance(nested, dict):  # FIX: C6-RT-20
+        containers.append(nested)  # FIX: C6-RT-20
+
+    details: list[str] = []  # FIX: C6-RT-20
+    seen: set[tuple[str, tuple[str, ...]]] = set()  # FIX: C6-RT-20
+    for container in containers:  # FIX: C6-RT-20
+        for category in _ACCESS_FINDING_CATEGORIES:  # FIX: C6-RT-20
+            entries = container.get(category)  # FIX: C6-RT-20
+            if not isinstance(entries, list):  # FIX: C6-RT-20
+                continue  # FIX: C6-RT-20
+            for entry in entries:  # FIX: C6-RT-20
+                if not isinstance(entry, dict):  # FIX: C6-RT-20
+                    continue  # FIX: C6-RT-20
+                if entry.get("status") != "incomplete_data":  # FIX: C6-RT-20
+                    continue  # FIX: C6-RT-20
+                check = str(entry.get("check") or category)  # FIX: C6-RT-20
+                raw_fields = entry.get("missing_fields") or []  # FIX: C6-RT-20
+                if isinstance(raw_fields, str):  # FIX: C6-RT-20
+                    raw_fields = [raw_fields]  # FIX: C6-RT-20
+                fields = tuple(str(f) for f in raw_fields)  # FIX: C6-RT-20
+                key = (check, fields)  # FIX: C6-RT-20
+                if key in seen:  # FIX: C6-RT-20
+                    continue  # FIX: C6-RT-20
+                seen.add(key)  # FIX: C6-RT-20
+                if len(fields) == 1:  # FIX: C6-RT-20
+                    reason = f"missing field: {fields[0]}"  # FIX: C6-RT-20
+                elif fields:  # FIX: C6-RT-20
+                    reason = f"missing fields: {', '.join(fields)}"  # FIX: C6-RT-20
+                else:  # FIX: C6-RT-20
+                    reason = "missing field not reported by the data source"  # FIX: C6-RT-20
+                details.append(  # FIX: C6-RT-20
+                    f"access review incomplete: check '{check}' "  # FIX: C6-RT-20
+                    f"could not run ({reason})"  # FIX: C6-RT-20
+                )  # FIX: C6-RT-20
+    return details  # FIX: C6-RT-20
+
+
+def _access_incomplete_controls(access: dict[str, Any] | None) -> list[str]:  # FIX: C6-RT-20
+    """Return the access compliance control keys whose status is ``incomplete``."""
+    if not isinstance(access, dict):  # FIX: C6-RT-20
+        return []  # FIX: C6-RT-20
+    comp = access.get("compliance")  # FIX: C6-RT-20
+    if not isinstance(comp, dict):  # FIX: C6-RT-20
+        return []  # FIX: C6-RT-20
+    return [str(k) for k, v in comp.items() if v == "incomplete"]  # FIX: C6-RT-20
+
+
 def _overall_status(
     compliance: dict[str, Any],
     certificates: dict[str, Any],
     vuln: dict[str, Any] | None,
     access: dict[str, Any] | None,
 ) -> str:
+    """Collapse every embedded section into one overall status string.
+
+    Access-review incompleteness maps to ``"warning"``, not ``"unknown"``
+    (FIX: C6-RT-20).  ``"unknown"`` is already reserved in this function for
+    "the report itself could not be assembled" - the
+    ``if "error" in compliance or "error" in certificates`` branch below.  An
+    access review that RAN but could not complete every check is a materially
+    different state, and it must not be collapsed into the same bucket as a
+    failed report load.  ``"warning"`` is the correct severity and is additive
+    to the existing access branch, which previously looked only at
+    ``inactive_count`` / ``privilege_creep_count`` and therefore reported
+    ``healthy`` for a review in which checks silently could not run.
+    """
     if "error" in compliance or "error" in certificates:
         return "unknown"
     # Critical: any compliance framework below 95 % or critical CVEs
@@ -109,6 +204,12 @@ def _overall_status(
         s = access.get("summary", {})
         if s.get("inactive_count", 0) > 0 or s.get("privilege_creep_count", 0) > 0:
             return "warning"
+        # A review that ran but could not complete every check is NOT healthy.
+        # `.get(..., 0)` keeps a pre-marker-schema artifact behaving as before.
+        if s.get("incomplete_data_count", 0) > 0:  # FIX: C6-RT-20
+            return "warning"  # FIX: C6-RT-20
+        if _access_incomplete_controls(access):  # FIX: C6-RT-20
+            return "warning"  # FIX: C6-RT-20
     return "healthy"
 
 
@@ -185,6 +286,29 @@ def _render_pdf(report: dict[str, Any], output_path: str) -> str | None:
         ))
         story.append(Spacer(1, 8))
 
+    # Access review section  # FIX: C6-RT-20
+    access = report.get("sections", {}).get("access_review_status")  # FIX: C6-RT-20
+    if isinstance(access, dict) and "error" not in access:  # FIX: C6-RT-20
+        a_summary = access.get("summary", {})  # FIX: C6-RT-20
+        if not isinstance(a_summary, dict):  # FIX: C6-RT-20
+            a_summary = {}  # FIX: C6-RT-20
+        story.append(Paragraph("Access Review", styles["Heading2"]))  # FIX: C6-RT-20
+        story.append(Paragraph(  # FIX: C6-RT-20
+            f"Inactive: {a_summary.get('inactive_count', 0)}"  # FIX: C6-RT-20
+            f"  Privilege creep: {a_summary.get('privilege_creep_count', 0)}"  # FIX: C6-RT-20
+            f"  Orphaned approvers: {a_summary.get('orphaned_approver_count', 0)}"  # FIX: C6-RT-20
+            f"  Checks that could not run: {a_summary.get('incomplete_data_count', 0)}",  # FIX: C6-RT-20
+            styles["Normal"],  # FIX: C6-RT-20
+        ))  # FIX: C6-RT-20
+        for detail in _access_incomplete_checks(access):  # FIX: C6-RT-20
+            story.append(Paragraph(f"\u2022 {detail}", styles["Normal"]))  # FIX: C6-RT-20
+        for control in _access_incomplete_controls(access):  # FIX: C6-RT-20
+            story.append(Paragraph(  # FIX: C6-RT-20
+                f"\u2022 control {control} is INCOMPLETE - not attested",  # FIX: C6-RT-20
+                styles["Normal"],  # FIX: C6-RT-20
+            ))  # FIX: C6-RT-20
+        story.append(Spacer(1, 8))  # FIX: C6-RT-20
+
     # Missing evidence
     missing = report.get("missing_evidence", [])
     if missing:
@@ -249,6 +373,33 @@ def generate_weekly_report(
     elif "error" in access:
         warnings.append(f"access review could not be loaded: {access['error']}")
         access = None
+    else:  # FIX: C6-RT-20
+        # An access review that RAN but could not complete every check must name
+        # the specific checks it skipped -- a generic "incomplete" string is not
+        # actionable for an auditor.  Marker detail is preferred; a pre-marker
+        # artifact (no markers, counts only) falls back to a count-based line.
+        incomplete_details = _access_incomplete_checks(access)  # FIX: C6-RT-20
+        incomplete_controls = _access_incomplete_controls(access)  # FIX: C6-RT-20
+        access_summary = access.get("summary", {})  # FIX: C6-RT-20
+        if not isinstance(access_summary, dict):  # FIX: C6-RT-20
+            access_summary = {}  # FIX: C6-RT-20
+        incomplete_count = access_summary.get("incomplete_data_count", 0)  # FIX: C6-RT-20
+        if incomplete_details:  # FIX: C6-RT-20
+            warnings.extend(incomplete_details)  # FIX: C6-RT-20
+        elif incomplete_count:  # FIX: C6-RT-20: guard on the count alone -- an
+            # 'incomplete' compliance control with a zero count is reported by the
+            # loop below, and folding it in here emitted "0 check(s) could not run",
+            # a false statement in an audit-facing warning.
+            warnings.append(  # FIX: C6-RT-20
+                f"access review incomplete: {incomplete_count} check(s) could "  # FIX: C6-RT-20
+                "not run; this artifact carries no per-check detail "  # FIX: C6-RT-20
+                "(re-run 'openclaw-cli scan access' to name them)"  # FIX: C6-RT-20
+            )  # FIX: C6-RT-20
+        for control in incomplete_controls:  # FIX: C6-RT-20
+            warnings.append(  # FIX: C6-RT-20
+                f"access review incomplete: compliance control {control} is "  # FIX: C6-RT-20
+                "'incomplete' - it is NOT attested by this report"  # FIX: C6-RT-20
+            )  # FIX: C6-RT-20
 
     if "error" in compliance:
         warnings.append(f"compliance reporter error: {compliance['error']}")

--- a/tests/unit/test_report_weekly_access.py
+++ b/tests/unit/test_report_weekly_access.py
@@ -1,0 +1,515 @@
+"""C6-RT-20: the weekly report must not discard the access-review signal.
+
+Covers ``clawdbot.report_weekly`` (backend) and the ``openclaw-cli scan access``
+counts table.  The pre-existing ``test_report_weekly_cli.py`` mocks the backend
+away entirely, so backend-level assertions live here instead.
+
+Every case below is robust against BOTH access artifacts:
+  * post-#136 artifacts carrying ``summary.incomplete_data_count`` plus
+    ``incomplete_data`` marker dicts inside the findings categories, and
+  * pre-#136 artifacts with neither key (must behave exactly as before).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from clawdbot.report_weekly import (  # FIX: C6-RT-20
+    _access_incomplete_checks,
+    _overall_status,
+    _render_pdf,
+    generate_weekly_report,
+)
+import clawdbot.report_weekly as report_weekly_mod  # FIX: C6-RT-20
+
+# ---------------------------------------------------------------------------
+# Load the CLI module directly (same idiom as test_report_weekly_cli.py)
+# ---------------------------------------------------------------------------
+_CLI_PATH = Path(__file__).resolve().parents[2] / "tools" / "openclaw-cli.py"
+_spec = importlib.util.spec_from_file_location("openclaw_cli_access_counts_tests", _CLI_PATH)
+assert _spec is not None and _spec.loader is not None
+_cli_mod = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _cli_mod
+_spec.loader.exec_module(_cli_mod)
+cli = _cli_mod.cli
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / builders
+# ---------------------------------------------------------------------------
+
+_CREEP_MARKER = {
+    "status": "incomplete_data",
+    "check": "production_access_in_non_prod_role",
+    "missing_fields": ["Systems"],
+    "issue": (
+        "production-access privilege-creep check could not run: "
+        "'Systems' field unavailable from this data source"
+    ),
+}
+
+_APPROVER_MARKER = {
+    "status": "incomplete_data",
+    "check": "orphaned_approver",
+    "missing_fields": ["GrantedBy"],
+    "issue": "orphaned-approver check could not run: 'GrantedBy' field unavailable",
+}
+
+
+def _access(*, inactive=0, creep=0, orphaned=0, incomplete=None, compliance=None, markers=False):
+    """Build an access-review payload.  ``incomplete=None`` omits the key entirely."""
+    summary = {
+        "total_users": 3,
+        "inactive_count": inactive,
+        "privilege_creep_count": creep,
+        "orphaned_approver_count": orphaned,
+    }
+    if incomplete is not None:
+        summary["incomplete_data_count"] = incomplete
+    payload: dict = {
+        "summary": summary,
+        "inactive_users": [],
+        "privilege_creep": [],
+        "orphaned_approvers": [],
+    }
+    if markers:
+        payload["privilege_creep"].append(dict(_CREEP_MARKER))
+        payload["orphaned_approvers"].append(dict(_APPROVER_MARKER))
+    if compliance is not None:
+        payload["compliance"] = compliance
+    return payload
+
+
+_PASS_COMPLIANCE = {"soc2_cc6_1": "pass", "iso27001_a9_2_5": "pass"}
+_INCOMPLETE_COMPLIANCE = {"soc2_cc6_1": "pass", "iso27001_a9_2_5": "incomplete"}
+
+
+# ---------------------------------------------------------------------------
+# _overall_status
+# ---------------------------------------------------------------------------
+
+class TestOverallStatusAccessIncompleteness:
+    """An access review that could not complete every check is not HEALTHY."""
+
+    def test_incomplete_data_count_is_not_healthy(self):
+        access = _access(incomplete=2, compliance=_INCOMPLETE_COMPLIANCE)
+        status = _overall_status({}, {}, None, access)
+        assert status != "healthy"
+        assert status == "warning"
+
+    def test_incomplete_count_alone_warns_with_passing_compliance(self):
+        access = _access(incomplete=2, compliance=_PASS_COMPLIANCE)
+        assert _overall_status({}, {}, None, access) == "warning"
+
+    def test_incomplete_compliance_control_alone_warns(self):
+        # incomplete_data_count is 0 but ISO 27001 A.9.2.5 could not be attested.
+        access = _access(incomplete=0, compliance=_INCOMPLETE_COMPLIANCE)
+        assert _overall_status({}, {}, None, access) == "warning"
+
+    def test_not_collapsed_into_unknown(self):
+        # "unknown" is reserved for a report that could not be assembled at all.
+        access = _access(incomplete=2, compliance=_INCOMPLETE_COMPLIANCE)
+        assert _overall_status({}, {}, None, access) != "unknown"
+
+    def test_unknown_still_wins_for_unassembled_report(self):
+        access = _access(incomplete=2, compliance=_INCOMPLETE_COMPLIANCE)
+        assert _overall_status({"error": "boom"}, {}, None, access) == "unknown"
+
+
+class TestOverallStatusRegressionGuards:
+    """Pre-existing behaviour must be untouched."""
+
+    def test_all_clean_is_healthy(self):
+        access = _access(incomplete=0, compliance=_PASS_COMPLIANCE)
+        assert _overall_status({}, {}, None, access) == "healthy"
+
+    def test_real_findings_still_warn_when_complete(self):
+        access = _access(inactive=1, incomplete=0, compliance=_PASS_COMPLIANCE)
+        assert _overall_status({}, {}, None, access) == "warning"
+
+    def test_privilege_creep_still_warns(self):
+        access = _access(creep=1, incomplete=0)
+        assert _overall_status({}, {}, None, access) == "warning"
+
+    def test_pre_136_artifact_without_incomplete_key_is_healthy(self):
+        access = _access()  # no incomplete_data_count key at all
+        assert "incomplete_data_count" not in access["summary"]
+        assert _overall_status({}, {}, None, access) == "healthy"
+
+    def test_pre_136_artifact_with_findings_still_warns(self):
+        access = _access(inactive=1)
+        assert _overall_status({}, {}, None, access) == "warning"
+
+    def test_no_access_section_is_healthy(self):
+        assert _overall_status({}, {}, None, None) == "healthy"
+
+    def test_critical_escalation_unchanged(self):
+        compliance = {"soc2": {"compliance_percentage": 80.0}}
+        access = _access(incomplete=5, compliance=_INCOMPLETE_COMPLIANCE)
+        assert _overall_status(compliance, {}, None, access) == "critical"
+
+    def test_critical_cve_still_beats_access_warning(self):
+        vuln = {"summary": {"critical": 1, "high": 0}}
+        access = _access(incomplete=5)
+        assert _overall_status({}, {}, vuln, access) == "critical"
+
+
+# ---------------------------------------------------------------------------
+# _access_incomplete_checks
+# ---------------------------------------------------------------------------
+
+class TestAccessIncompleteChecks:
+
+    def test_markers_are_named(self):
+        details = _access_incomplete_checks(_access(incomplete=2, markers=True))
+        joined = " | ".join(details)
+        assert "production_access_in_non_prod_role" in joined
+        assert "Systems" in joined
+        assert "orphaned_approver" in joined
+        assert "GrantedBy" in joined
+
+    def test_real_findings_are_not_treated_as_markers(self):
+        access = _access(inactive=1)
+        access["inactive_users"].append({"user": "alice", "last_login": "2025-01-01"})
+        assert _access_incomplete_checks(access) == []
+
+    def test_pre_136_artifact_yields_no_detail(self):
+        assert _access_incomplete_checks(_access()) == []
+
+    def test_nested_findings_layout_supported(self):
+        access = {"summary": {"incomplete_data_count": 1},
+                  "findings": {"privilege_creep": [dict(_CREEP_MARKER)]}}
+        details = _access_incomplete_checks(access)
+        assert len(details) == 1
+        assert "production_access_in_non_prod_role" in details[0]
+
+    def test_none_and_garbage_do_not_raise(self):
+        assert _access_incomplete_checks(None) == []
+        assert _access_incomplete_checks({"privilege_creep": "not-a-list"}) == []
+        assert _access_incomplete_checks({"privilege_creep": ["not-a-dict"]}) == []
+
+
+# ---------------------------------------------------------------------------
+# generate_weekly_report
+# ---------------------------------------------------------------------------
+
+def _healthy_compliance():
+    return {"soc2": {"compliance_percentage": 99.0}, "iso27001": {"compliance_percentage": 99.0}}
+
+
+def _healthy_certs():
+    return {"total": 2, "expiring_soon": 0, "certificates": []}
+
+
+def _run_report(tmp_path, access_payload, **kwargs):
+    access_file = tmp_path / "access.json"
+    access_file.write_text(json.dumps(access_payload), encoding="utf-8")
+    with (
+        patch.object(report_weekly_mod, "_gather_compliance", return_value=_healthy_compliance()),
+        patch.object(report_weekly_mod, "_gather_certificates", return_value=_healthy_certs()),
+    ):
+        return generate_weekly_report(
+            start_date="2026-03-14",
+            end_date="2026-03-21",
+            access_scan_path=str(access_file),
+            **kwargs,
+        )
+
+
+class TestGenerateWeeklyReportSurfacesIncompleteness:
+
+    def test_warnings_name_the_specific_unrun_check(self, tmp_path):
+        report = _run_report(
+            tmp_path, _access(incomplete=2, compliance=_INCOMPLETE_COMPLIANCE, markers=True)
+        )
+        joined = " | ".join(report["warnings"])
+        assert "production_access_in_non_prod_role" in joined
+        assert "Systems" in joined
+        assert "orphaned_approver" in joined
+
+    def test_status_is_warning_not_healthy(self, tmp_path):
+        report = _run_report(
+            tmp_path, _access(incomplete=2, compliance=_INCOMPLETE_COMPLIANCE, markers=True)
+        )
+        assert report["overall_status"] == "warning"
+
+    def test_incomplete_compliance_control_named_in_warnings(self, tmp_path):
+        report = _run_report(tmp_path, _access(incomplete=0, compliance=_INCOMPLETE_COMPLIANCE))
+        joined = " | ".join(report["warnings"])
+        assert "iso27001_a9_2_5" in joined
+
+    def test_count_only_artifact_falls_back_to_count_message(self, tmp_path):
+        # Counts say incomplete but no marker detail is present.
+        report = _run_report(tmp_path, _access(incomplete=3, compliance=_PASS_COMPLIANCE))
+        joined = " | ".join(report["warnings"])
+        assert "access review incomplete" in joined
+        assert "3" in joined
+        assert report["overall_status"] == "warning"
+
+    def test_clean_review_adds_no_access_warning(self, tmp_path):
+        report = _run_report(tmp_path, _access(incomplete=0, compliance=_PASS_COMPLIANCE))
+        assert [w for w in report["warnings"] if "access review incomplete" in w] == []
+        assert report["overall_status"] == "healthy"
+
+    def test_pre_136_artifact_adds_no_access_warning(self, tmp_path):
+        report = _run_report(tmp_path, _access())
+        assert [w for w in report["warnings"] if "access review incomplete" in w] == []
+        assert report["overall_status"] == "healthy"
+
+    def test_unloadable_access_file_still_warns_as_before(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json", encoding="utf-8")
+        with (
+            patch.object(report_weekly_mod, "_gather_compliance", return_value=_healthy_compliance()),
+            patch.object(report_weekly_mod, "_gather_certificates", return_value=_healthy_certs()),
+        ):
+            report = generate_weekly_report(
+                start_date="2026-03-14", end_date="2026-03-21", access_scan_path=str(bad)
+            )
+        assert any("access review could not be loaded" in w for w in report["warnings"])
+
+
+class TestGenerateWeeklyReportAgainstRealProducerLayout:  # FIX: C6-RT-20
+    """End-to-end against the EXACT dict `run_access_review` writes to disk.
+
+    The other tests in this file build the finding categories at the top level.
+    The real producer (src/clawdbot/scan_access.py) nests them under a
+    ``"findings"`` mapping alongside ``summary`` and ``compliance``.  A consumer
+    fix that only ever sees the flat shape in its tests would pass here and still
+    discard the signal on a real artifact -- which is the very failure class
+    C6-RT-20 exists to close.  These cases pin the nested layout.
+    """
+
+    @staticmethod
+    def _producer_payload():  # FIX: C6-RT-20
+        # Mirrors run_access_review()'s result dict for provider="azure-ad".
+        return {  # FIX: C6-RT-20
+            "command": "scan access",  # FIX: C6-RT-20
+            "generated_at": "2026-03-21T00:00:00+00:00",  # FIX: C6-RT-20
+            "input_source": "azure-ad",  # FIX: C6-RT-20
+            "days_threshold": 90,  # FIX: C6-RT-20
+            "findings": {  # FIX: C6-RT-20
+                "inactive_users": [],  # FIX: C6-RT-20
+                "privilege_creep": [dict(_CREEP_MARKER)],  # FIX: C6-RT-20
+                "orphaned_approvers": [dict(_APPROVER_MARKER)],  # FIX: C6-RT-20
+            },  # FIX: C6-RT-20
+            "summary": {  # FIX: C6-RT-20
+                "total_users": 3,  # FIX: C6-RT-20
+                "inactive_count": 0,  # FIX: C6-RT-20
+                "privilege_creep_count": 0,  # FIX: C6-RT-20
+                "orphaned_approver_count": 0,  # FIX: C6-RT-20
+                "incomplete_data_count": 2,  # FIX: C6-RT-20
+            },  # FIX: C6-RT-20
+            "compliance": dict(_INCOMPLETE_COMPLIANCE),  # FIX: C6-RT-20
+        }  # FIX: C6-RT-20
+
+    def test_nested_producer_payload_is_not_healthy(self, tmp_path):  # FIX: C6-RT-20
+        report = _run_report(tmp_path, self._producer_payload())  # FIX: C6-RT-20
+        assert report["overall_status"] == "warning"  # FIX: C6-RT-20
+
+    def test_nested_producer_payload_names_the_unrun_checks(self, tmp_path):  # FIX: C6-RT-20
+        report = _run_report(tmp_path, self._producer_payload())  # FIX: C6-RT-20
+        joined = " | ".join(report["warnings"])  # FIX: C6-RT-20
+        # The specific check names must survive the nesting, not a generic string.
+        assert "production_access_in_non_prod_role" in joined  # FIX: C6-RT-20
+        assert "Systems" in joined  # FIX: C6-RT-20
+        assert "orphaned_approver" in joined  # FIX: C6-RT-20
+        assert "GrantedBy" in joined  # FIX: C6-RT-20
+        # And the count-only fallback must NOT fire when real detail exists.
+        assert "carries no per-check detail" not in joined  # FIX: C6-RT-20
+
+    def test_nested_clean_producer_payload_stays_healthy(self, tmp_path):  # FIX: C6-RT-20
+        payload = self._producer_payload()  # FIX: C6-RT-20
+        payload["findings"]["privilege_creep"] = []  # FIX: C6-RT-20
+        payload["findings"]["orphaned_approvers"] = []  # FIX: C6-RT-20
+        payload["summary"]["incomplete_data_count"] = 0  # FIX: C6-RT-20
+        payload["compliance"] = dict(_PASS_COMPLIANCE)  # FIX: C6-RT-20
+        payload["input_source"] = "csv"  # FIX: C6-RT-20
+        report = _run_report(tmp_path, payload)  # FIX: C6-RT-20
+        assert report["overall_status"] == "healthy"  # FIX: C6-RT-20
+        assert [w for w in report["warnings"] if "access review incomplete" in w] == []  # FIX: C6-RT-20
+
+
+# ---------------------------------------------------------------------------
+# PDF rendering
+# ---------------------------------------------------------------------------
+
+def _install_fake_reportlab(monkeypatch, captured: list[str]):
+    """Install a minimal in-memory reportlab so _render_pdf runs without the dep.
+
+    reportlab is not a test dependency of this repo, so the real-PDF tests below
+    are importorskip-guarded.  This stub exercises the same code path and lets us
+    assert on the exact text the access section emits.
+    """
+    import types
+
+    rl = types.ModuleType("reportlab")
+    lib = types.ModuleType("reportlab.lib")
+    pagesizes = types.ModuleType("reportlab.lib.pagesizes")
+    pagesizes.letter = (612.0, 792.0)
+    styles_mod = types.ModuleType("reportlab.lib.styles")
+    styles_mod.getSampleStyleSheet = lambda: {
+        "Title": "Title", "Normal": "Normal", "Heading2": "Heading2",
+    }
+    platypus = types.ModuleType("reportlab.platypus")
+
+    class _Paragraph:
+        def __init__(self, text, style=None):
+            self.text = text
+
+    class _Spacer:
+        def __init__(self, *args):
+            pass
+
+    class _SimpleDocTemplate:
+        def __init__(self, path, **kwargs):
+            self.path = path
+
+        def build(self, story):
+            captured.extend(getattr(item, "text", "") for item in story)
+            Path(self.path).write_bytes(b"%PDF-1.4 stub")
+
+    platypus.Paragraph = _Paragraph
+    platypus.Spacer = _Spacer
+    platypus.SimpleDocTemplate = _SimpleDocTemplate
+
+    for name, module in (
+        ("reportlab", rl),
+        ("reportlab.lib", lib),
+        ("reportlab.lib.pagesizes", pagesizes),
+        ("reportlab.lib.styles", styles_mod),
+        ("reportlab.platypus", platypus),
+    ):
+        monkeypatch.setitem(sys.modules, name, module)
+
+
+class TestRenderPdfAccessSectionText:
+    """Assert on the rendered text via a stubbed reportlab."""
+
+    def test_access_section_shows_four_counts_and_named_checks(self, tmp_path, monkeypatch):
+        report = _run_report(
+            tmp_path, _access(inactive=1, incomplete=2,
+                              compliance=_INCOMPLETE_COMPLIANCE, markers=True)
+        )
+        captured: list[str] = []
+        _install_fake_reportlab(monkeypatch, captured)
+        assert _render_pdf(report, str(tmp_path / "r.pdf")) is not None
+        text = "\n".join(captured)
+        assert "Access Review" in text
+        assert "Inactive: 1" in text
+        assert "Privilege creep: 0" in text
+        assert "Orphaned approvers: 0" in text
+        assert "Checks that could not run: 2" in text
+        assert "production_access_in_non_prod_role" in text
+        assert "iso27001_a9_2_5" in text
+
+    def test_pre_136_artifact_renders_zero_incomplete(self, tmp_path, monkeypatch):
+        report = _run_report(tmp_path, _access())
+        captured: list[str] = []
+        _install_fake_reportlab(monkeypatch, captured)
+        assert _render_pdf(report, str(tmp_path / "r.pdf")) is not None
+        text = "\n".join(captured)
+        assert "Access Review" in text
+        assert "Checks that could not run: 0" in text
+
+    def test_no_access_section_when_absent(self, tmp_path, monkeypatch):
+        captured: list[str] = []
+        _install_fake_reportlab(monkeypatch, captured)
+        report = {
+            "period": {"start": "2026-03-14", "end": "2026-03-21"},
+            "generated_at": "2026-03-21T00:00:00+00:00",
+            "overall_status": "healthy",
+            "sections": {
+                "compliance_status": {},
+                "certificate_status": {"total": 0, "expiring_soon": 0},
+                "vulnerability_summary": None,
+                "access_review_status": None,
+            },
+            "missing_evidence": [],
+            "warnings": [],
+        }
+        assert _render_pdf(report, str(tmp_path / "r.pdf")) is not None
+        assert "Access Review" not in "\n".join(captured)
+
+
+class TestRenderPdfAccessSection:
+
+    def test_pdf_includes_access_section(self, tmp_path):
+        pytest.importorskip("reportlab")
+        report = _run_report(
+            tmp_path, _access(incomplete=2, compliance=_INCOMPLETE_COMPLIANCE, markers=True)
+        )
+        pdf_path = tmp_path / "report.pdf"
+        written = _render_pdf(report, str(pdf_path))
+        assert written is not None
+        assert Path(written).exists()
+        assert Path(written).stat().st_size > 0
+
+    def test_pdf_renders_without_access_section(self, tmp_path):
+        pytest.importorskip("reportlab")
+        pdf_path = tmp_path / "no-access.pdf"
+        report = {
+            "period": {"start": "2026-03-14", "end": "2026-03-21"},
+            "generated_at": "2026-03-21T00:00:00+00:00",
+            "overall_status": "healthy",
+            "sections": {
+                "compliance_status": {},
+                "certificate_status": {"total": 0, "expiring_soon": 0},
+                "vulnerability_summary": None,
+                "access_review_status": None,
+            },
+            "missing_evidence": [],
+            "warnings": [],
+        }
+        assert _render_pdf(report, str(pdf_path)) is not None
+
+
+# ---------------------------------------------------------------------------
+# CLI access counts table
+# ---------------------------------------------------------------------------
+
+def _cli_access_result(summary_extra: dict):
+    summary = {
+        "total_users": 3,
+        "inactive_count": 0,
+        "privilege_creep_count": 0,
+        "orphaned_approver_count": 0,
+    }
+    summary.update(summary_extra)
+    return {
+        "summary": summary,
+        "input_source": "access-export.csv",
+        "compliance": _INCOMPLETE_COMPLIANCE,
+    }
+
+
+class TestScanAccessCountsTable:
+
+    def _invoke(self, monkeypatch, result):
+        mod = SimpleNamespace(run_access_review=lambda **kw: result)
+        monkeypatch.setattr(_cli_mod, "_load_clawdbot_module", lambda _n: mod)
+        runner = CliRunner()
+        return runner.invoke(cli, ["scan", "access", "--input-csv", "access-export.csv"])
+
+    def test_incomplete_count_is_printed(self, monkeypatch):
+        out = self._invoke(monkeypatch, _cli_access_result({"incomplete_data_count": 2}))
+        assert out.exit_code == 0, out.output
+        assert "Incomplete checks" in out.output
+
+    def test_incomplete_row_hidden_when_zero(self, monkeypatch):
+        out = self._invoke(monkeypatch, _cli_access_result({"incomplete_data_count": 0}))
+        assert out.exit_code == 0, out.output
+        assert "Incomplete checks" not in out.output
+
+    def test_pre_136_payload_does_not_keyerror(self, monkeypatch):
+        out = self._invoke(monkeypatch, _cli_access_result({}))
+        assert out.exit_code == 0, out.output
+        assert "Incomplete checks" not in out.output

--- a/tools/openclaw-cli.py
+++ b/tools/openclaw-cli.py
@@ -755,6 +755,9 @@ def access(ctx, days, input_csv, provider, tenant_id, client_id, client_secret,
         ["  Privilege creep", "", summary["privilege_creep_count"]],
         ["  Orphaned approvers", "", summary["orphaned_approver_count"]],
     ]
+    incomplete_count = summary.get("incomplete_data_count", 0)  # FIX: C6-RT-20
+    if incomplete_count:  # FIX: C6-RT-20
+        rows_out.append(["  Incomplete checks", "could not run", incomplete_count])  # FIX: C6-RT-20
     click.echo(tabulate(rows_out, headers=["Category", "Condition", "Count"]))
 
     comp = result.get("compliance", {})


### PR DESCRIPTION
Closes #139

**This unblocks the C6-RT-08 sign-off.** PR #136 makes the `scan access` JSON honest; this is why that was not yet true end-to-end (Rule 2).

`_overall_status()` inspected the access review through a single condition on `inactive_count` and `privilege_creep_count`. It ignored `summary.incomplete_data_count`, ignored the access `compliance` dict entirely including `iso27001_a9_2_5 == "incomplete"`, and contributed nothing to `warnings` or `missing_evidence`. `_render_pdf()` rendered no access section at all, and the CLI printed only three counts.

**Net effect:** an azure-ad access review in which two of three checks *could not run* was presented to an auditor as `Overall Status: HEALTHY` with an empty warnings list. The signal existed in the JSON and was discarded at the consumer.

### Changes
- `_overall_status` returns `"warning"` when `incomplete_data_count > 0` or any access compliance value is `"incomplete"`. **`"warning"` not `"unknown"`:** `"unknown"` is already reserved in this function for *"the report itself could not be assembled"* (the error branch on compliance/certificates). A review that ran but could not complete every check is a materially different state and must not collapse into the same bucket. Documented in the docstring.
- `generate_weekly_report` names the **specific** checks that could not run, derived from each marker's `check` and `missing_fields` keys — not a generic string. A count-only artifact falls back to a count-based line; an `"incomplete"` compliance control is reported separately and accurately.
- `_render_pdf` gained an access section, so the PDF reader sees the four counts and the named unrun checks instead of only a status line.
- `openclaw-cli scan access` prints `incomplete_data_count` when non-zero.

### Robustness
Consumer reads are layout-agnostic (categories at the top level or nested under `"findings"`, which is what the producer actually emits) and degrade cleanly on a pre-#136 artifact that has neither markers nor the `incomplete_data_count` key — absence is treated as zero and never raises.

### Verification
Full suite **467 passed / 5 skipped** against a 433/3 baseline on `main` — the delta is exactly this PR's new tests. Tests cover both layouts, including an end-to-end case built to mirror exactly what `run_access_review` writes to disk, plus regression guards that a clean review is still healthy, real findings still warn, and a pre-marker artifact behaves as before.

The `_overall_status` signature, the critical escalation rules and the certificate/high-CVE rules are untouched; this is additive to the access branch only.