### PR TITLE
fix(C6-RT-19): scan_access azure-ad path stops claiming a role-based privilege-creep check it cannot perform

### DIFF
--- a/src/clawdbot/scan_access.py
+++ b/src/clawdbot/scan_access.py
@@ -19,10 +19,29 @@ azure-ad
     variables: AZURE_AD_TENANT_ID, AZURE_AD_CLIENT_ID, AZURE_AD_CLIENT_SECRET.
 
     NOT every rule above runs for this source.  The basic Graph user query
-    cannot supply the columns named in ``AZURE_AD_UNAVAILABLE_FIELDS``, so the
-    prod-access privilege-creep sub-rule and the orphaned-approver check are
-    reported as ``status="incomplete_data"`` rather than as a clean result.
-    See that constant for the authoritative list.
+    cannot supply a trustworthy value for the columns named in
+    ``AZURE_AD_UNAVAILABLE_FIELDS``, so every check that depends on one of them
+    is reported as ``status="incomplete_data"`` rather than as a clean result.
+    See that constant for the authoritative list.  Concretely, for azure-ad:
+
+      - Inactive-user detection RUNS, subject to one precondition: ``LastLogin``
+        comes from ``signInActivity``, which requires an Azure AD Premium P1/P2
+        licence on the tenant.  Without it the field is absent and every user is
+        flagged "no login date recorded" — noisy, but it fails toward review
+        rather than toward a clean result.
+      - Prod-access privilege-creep sub-rule DOES NOT RUN — ``Systems`` is
+        hardcoded ``""``; the basic user query has no system-entitlement data.
+      - Admin+Developer privilege-creep sub-rule DOES NOT RUN as an entitlement
+        check — ``Role`` is populated from the Graph ``jobTitle`` profile
+        attribute, which is free-text HR metadata, not an entitlement.  Real
+        Azure AD entitlements live in ``/directoryRoles``,
+        ``appRoleAssignments`` and group memberships, none of which are queried
+        (doing so would require additional Graph scopes such as
+        ``RoleManagement.Read.Directory`` / ``Directory.Read.All``).  No
+        Role-derived privilege-creep finding is emitted for this source at all,
+        so the marker's "could not run" claim is not contradicted by a finding
+        sitting beside it.  See C6-RT-19.
+      - Orphaned-approver check DOES NOT RUN — ``GrantedBy`` is hardcoded ``""``.
 
 SECURITY NOTE
 -------------
@@ -142,7 +161,22 @@ def _graph_get(endpoint: str, token: str) -> dict[str, Any]:
 # (see load_azure_ad below — Systems/GrantedBy are hardcoded ""). Checks that depend
 # on them therefore did NOT run for the azure-ad source; they must be reported as
 # incomplete_data, never as a clean/zero result (which was false-clean evidence).
-AZURE_AD_UNAVAILABLE_FIELDS = frozenset({"Systems", "GrantedBy"})  # FIX: C6-RT-08
+#
+# FIX: C6-RT-19: "unavailable" here means the source cannot supply a TRUSTWORTHY
+# value for the access-review semantics of that column — NOT merely that the column
+# comes out empty. Two distinct cases are listed:
+#   Systems, GrantedBy — literally absent: load_azure_ad hardcodes them to "".
+#   Role               — POPULATED BUT SEMANTICALLY WRONG: load_azure_ad fills it
+#                        from the Graph `jobTitle` profile attribute, which is
+#                        free-text HR metadata. Entitlements actually live in
+#                        /directoryRoles, appRoleAssignments and group memberships,
+#                        which this module deliberately does not query (that would
+#                        require added Graph scopes — a permissions change, not a
+#                        fix). A jobTitle can never be relied on to satisfy the
+#                        Admin+Developer entitlement test, so that sub-rule cannot
+#                        run as an entitlement check on this source.
+# Every field named here forces an incomplete_data marker on its dependent check.
+AZURE_AD_UNAVAILABLE_FIELDS = frozenset({"Systems", "GrantedBy", "Role"})  # FIX: C6-RT-19
 
 
 @read_only_io
@@ -222,10 +256,14 @@ def analyze_access(
       - privilege_creep
       - orphaned_approvers
 
-    ``unavailable_fields`` names columns the data source could not supply (e.g.
-    the azure-ad provider cannot populate Systems/GrantedBy). Checks that depend
-    on such a field are reported with an explicit ``status="incomplete_data"``
-    marker instead of silently returning no findings — see C6-RT-08.
+    ``unavailable_fields`` names columns for which the data source cannot supply
+    a trustworthy value — either because the column is absent (the azure-ad
+    provider hardcodes Systems/GrantedBy to ""), or because the value it does
+    supply does not mean what the check needs it to mean (the azure-ad Role
+    column carries a Graph ``jobTitle``, not an entitlement — C6-RT-19). Checks
+    that depend on such a field are reported with an explicit
+    ``status="incomplete_data"`` marker instead of silently returning no
+    findings — see C6-RT-08.
     """
     unavailable_fields = unavailable_fields or frozenset()  # FIX: C6-RT-08
     now = datetime.now(UTC)
@@ -271,7 +309,18 @@ def analyze_access(
         # --- Privilege-creep rules ---
         roles = {r.strip().lower() for r in role_raw.split(",") if r.strip()}
 
-        if "admin" in roles and "developer" in roles:
+        # FIX: C6-RT-19: both sub-rules below read `roles`, so both are only meaningful
+        # when the Role column actually carries entitlement data. On a source where it
+        # does not (azure-ad fills Role from the Graph jobTitle profile attribute), a
+        # match is a coincidence of HR job titles, not a privilege finding. Emitting it
+        # as a real finding would contradict the incomplete_data marker emitted below --
+        # the same array would assert the check could not run AND report its verdict --
+        # and, because markers are excluded from the privilege-creep CSV export, it would
+        # reach that artifact as an uncaveated entitlement finding. The marker is the
+        # only honest output for such a source.
+        role_data_is_entitlement = "Role" not in unavailable_fields  # FIX: C6-RT-19
+
+        if role_data_is_entitlement and "admin" in roles and "developer" in roles:  # FIX: C6-RT-19
             privilege_creep.append({
                 "user_id": user_id,
                 "email": email,
@@ -282,7 +331,11 @@ def analyze_access(
 
         prod_access = any(s.lower() in ("prod", "production") for s in systems)
         non_prod_roles = {"developer", "operator", "viewer", "read-only"}
-        if prod_access and roles and roles.issubset(non_prod_roles) and user_id not in already_flagged_creep:
+        if (  # FIX: C6-RT-19
+            role_data_is_entitlement  # FIX: C6-RT-19
+            and prod_access and roles and roles.issubset(non_prod_roles)
+            and user_id not in already_flagged_creep
+        ):
             privilege_creep.append({
                 "user_id": user_id,
                 "email": email,
@@ -314,6 +367,24 @@ def analyze_access(
                 "'Systems' field unavailable from this data source"  # FIX: C6-RT-08
             ),  # FIX: C6-RT-08
         })  # FIX: C6-RT-08
+    # FIX: C6-RT-19: the Role column can be populated yet still unable to answer the
+    # entitlement question (azure-ad fills it from the Graph jobTitle attribute). The
+    # admin_developer_combo sub-rule is therefore inert on that source; report it as
+    # incomplete_data so a privilege_creep count of 0 is never read as "no creep found".
+    if "Role" in unavailable_fields:  # FIX: C6-RT-19
+        privilege_creep.append({  # FIX: C6-RT-19
+            "status": "incomplete_data",  # FIX: C6-RT-19
+            "check": "admin_developer_combo",  # FIX: C6-RT-19
+            "missing_fields": ["Role"],  # FIX: C6-RT-19
+            "issue": (  # FIX: C6-RT-19
+                "role-based privilege-creep check could not run: the azure-ad "  # FIX: C6-RT-19
+                "'Role' column is derived from the Microsoft Graph 'jobTitle' "  # FIX: C6-RT-19
+                "profile attribute rather than from a directory-role or app-role "  # FIX: C6-RT-19
+                "assignment query, so it carries no entitlement data. No "  # FIX: C6-RT-19
+                "Role-derived privilege-creep finding is reported for this "  # FIX: C6-RT-19
+                "source; entitlements were not reviewed"  # FIX: C6-RT-19
+            ),  # FIX: C6-RT-19
+        })  # FIX: C6-RT-19
     if "GrantedBy" in unavailable_fields:  # FIX: C6-RT-08
         orphaned_approvers.append({  # FIX: C6-RT-08
             "status": "incomplete_data",  # FIX: C6-RT-08
@@ -391,20 +462,32 @@ def run_access_review(
 
     input_source = "csv" if input_csv else provider
 
+    # FIX: C6-RT-19: choose the loader and declare its unavailable fields in ONE
+    # branch. Previously the loader was a catch-all `else:` (any non-CSV provider got
+    # load_azure_ad) while unavailable_fields was gated on `input_source == "azure-ad"`
+    # by exact string match. Those two could disagree: provider="Azure-AD" or
+    # "azure_ad" pulled real Microsoft Graph data and then reported zero
+    # incomplete_data markers with iso27001_a9_2_5 "pass" -- a trustworthy-looking
+    # clean review of checks that never ran, the exact false-clean class this finding
+    # exists to remove. Binding them together makes that drift unrepresentable, and an
+    # unrecognised provider now fails closed instead of silently reporting clean.
     if input_csv:
         rows = load_csv(input_csv)
-    else:
+        unavailable_fields: frozenset[str] = frozenset()  # FIX: C6-RT-19
+    elif input_source == "azure-ad":  # FIX: C6-RT-19
         rows = load_azure_ad(
             tenant_id=tenant_id,
             client_id=client_id,
             client_secret=client_secret,
         )
-
-    # FIX: C6-RT-08: declare which required fields the source cannot supply, so
-    # analyze_access reports dependent checks as incomplete rather than clean.
-    unavailable_fields = (  # FIX: C6-RT-08
-        AZURE_AD_UNAVAILABLE_FIELDS if input_source == "azure-ad" else frozenset()  # FIX: C6-RT-08
-    )  # FIX: C6-RT-08
+        # FIX: C6-RT-08: declare which required fields the source cannot supply, so
+        # analyze_access reports dependent checks as incomplete rather than clean.
+        unavailable_fields = AZURE_AD_UNAVAILABLE_FIELDS  # FIX: C6-RT-08
+    else:  # FIX: C6-RT-19
+        raise ValueError(  # FIX: C6-RT-19
+            f"Unsupported provider {provider!r}. Supported providers: 'azure-ad'. "  # FIX: C6-RT-19
+            "Refusing to run rather than report checks that never ran as clean."  # FIX: C6-RT-19
+        )  # FIX: C6-RT-19
 
     findings = analyze_access(  # FIX: C6-RT-08
         rows,
@@ -434,8 +517,12 @@ def run_access_review(
     # (ISO 27001 A.9.2.5) could not fully run -> report "incomplete", never "pass".
     compliance = {
         "soc2_cc6_1": "warn" if summary["inactive_count"] > 0 else "pass",
+        # FIX: C6-RT-19: Role joins the gate set. A.9.2.5 is a review of *entitlements*,
+        # and each of these three fields is independently load-bearing for it: if Systems
+        # and GrantedBy ever became available, a jobTitle-derived Role would still leave
+        # the entitlement review unperformed, so Role alone must still force "incomplete".
         "iso27001_a9_2_5": (  # FIX: C6-RT-08
-            "incomplete" if unavailable_fields & {"Systems", "GrantedBy"}  # FIX: C6-RT-08
+            "incomplete" if unavailable_fields & {"Systems", "GrantedBy", "Role"}  # FIX: C6-RT-19
             else "warn" if summary["privilege_creep_count"] > 0  # FIX: C6-RT-08
             else "pass"  # FIX: C6-RT-08
         ),

--- a/tests/security/test_vulnerability_scanning.py
+++ b/tests/security/test_vulnerability_scanning.py
@@ -380,12 +380,29 @@ class TestJiraTicketCreation:
 # ---------------------------------------------------------------------------
 
 class TestAccessReviewIncompleteData:
-    """C6-RT-08 — incomplete-data reporting for sources missing required fields."""
+    """C6-RT-08 / C6-RT-19 — incomplete-data reporting for untrustworthy fields.
+
+    C6-RT-08 covered fields that are ABSENT (Systems/GrantedBy == "").
+    C6-RT-19 adds the field that is POPULATED BUT MEANS THE WRONG THING: the
+    azure-ad Role column carries a Graph jobTitle, not an entitlement, so the
+    admin_developer_combo sub-rule is inert there and must say so.
+    """  # FIX: C6-RT-19
 
     def _azure_rows(self):
-        """Rows as load_azure_ad() would emit: Systems/GrantedBy hardcoded empty."""
+        """SYNTHETIC azure-shaped rows — NOT provider-representative for ``Role``.
+
+        Shape is faithful to load_azure_ad(): Systems/GrantedBy hardcoded empty.
+        ``Role`` is NOT: the real provider fills it from the Graph ``jobTitle``
+        profile attribute (free-text HR metadata), so a value like
+        "Admin,Developer" is manufactured and will essentially never occur in
+        live data — see C6-RT-19 and ``_azure_rows_provider_realistic`` below.
+        This fixture exists only to prove that the C6-RT-08 marker plumbing
+        keeps real findings and markers separated; it must never be read as
+        evidence that the role sub-rule works on azure-ad entitlements.
+        """  # FIX: C6-RT-19
         recent = (datetime.now(UTC) - timedelta(days=5)).strftime("%Y-%m-%d")
         return [
+            # FIX: C6-RT-19: synthetic Role — a real Graph jobTitle is never "Admin,Developer"
             {  # privilege creep detectable from Role alone (Admin+Developer)
                 "UserID": "az1", "Name": "Admin Dev", "Email": "ad@corp.com",
                 "Role": "Admin,Developer", "Systems": "", "LastLogin": recent,
@@ -396,6 +413,29 @@ class TestAccessReviewIncompleteData:
                 "Role": "Viewer", "Systems": "", "LastLogin": "",
                 "GrantedDate": "2024-02-01", "GrantedBy": "", "_source": "azure_ad",
             },
+        ]
+
+    def _azure_rows_provider_realistic(self):
+        """Azure rows whose ``Role`` holds a REAL Graph jobTitle. C6-RT-19.
+
+        The user below is the finding's worked example: a Global Administrator
+        with developer app-role assignments whose HR jobTitle is
+        "Security Analyst". No role sub-rule can fire on that string.
+        """  # FIX: C6-RT-19
+        recent = (datetime.now(UTC) - timedelta(days=5)).strftime("%Y-%m-%d")
+        return [  # FIX: C6-RT-19
+            {  # FIX: C6-RT-19
+                "UserID": "az10", "Name": "Dana Real", "Email": "dana@corp.com",
+                "Role": "Security Analyst",   # FIX: C6-RT-19: Graph jobTitle, not an entitlement
+                "Systems": "", "LastLogin": recent,
+                "GrantedDate": "2024-03-01", "GrantedBy": "", "_source": "azure_ad",
+            },  # FIX: C6-RT-19
+            {  # FIX: C6-RT-19
+                "UserID": "az11", "Name": "Eli Real", "Email": "eli@corp.com",
+                "Role": "Senior Platform Engineer",  # FIX: C6-RT-19: jobTitle again
+                "Systems": "", "LastLogin": recent,
+                "GrantedDate": "2024-04-01", "GrantedBy": "", "_source": "azure_ad",
+            },  # FIX: C6-RT-19
         ]
 
     def test_csv_path_is_byte_stable_with_no_markers(self, sample_access_rows):
@@ -418,13 +458,30 @@ class TestAccessReviewIncompleteData:
         )
         creep_markers = [f for f in findings["privilege_creep"] if f.get("status") == "incomplete_data"]
         orphan_markers = [f for f in findings["orphaned_approvers"] if f.get("status") == "incomplete_data"]
-        assert len(creep_markers) == 1
-        assert creep_markers[0]["missing_fields"] == ["Systems"]
+        # FIX: C6-RT-19: both privilege-creep sub-rules are now declared unavailable.
+        assert len(creep_markers) == 2  # FIX: C6-RT-19
+        by_check = {m["check"]: m for m in creep_markers}  # FIX: C6-RT-19
+        assert by_check["production_access_in_non_prod_role"]["missing_fields"] == ["Systems"]
+        assert by_check["admin_developer_combo"]["missing_fields"] == ["Role"]  # FIX: C6-RT-19
         assert len(orphan_markers) == 1
         assert orphan_markers[0]["missing_fields"] == ["GrantedBy"]
-        # The Role-based privilege-creep sub-rule still works (real finding survives).
-        real_creep = [f for f in findings["privilege_creep"] if f.get("status") != "incomplete_data"]
-        assert any("admin" in " ".join(f.get("roles", [])).lower() for f in real_creep)
+        # FIX: C6-RT-19: every marker carries the C6-RT-08 shape, exactly these keys.
+        for marker in creep_markers + orphan_markers:  # FIX: C6-RT-19
+            assert set(marker) == {"status", "check", "missing_fields", "issue"}  # FIX: C6-RT-19
+        # FIX: C6-RT-19: the marker must name jobTitle as the reason, not claim the
+        # column is absent — Role IS populated, it just isn't an entitlement.
+        role_issue = by_check["admin_developer_combo"]["issue"]  # FIX: C6-RT-19
+        assert "jobTitle" in role_issue  # FIX: C6-RT-19
+        assert "could not run" in role_issue  # FIX: C6-RT-19
+        # FIX: C6-RT-19: the sub-rule must NOT also emit a real finding on this source.
+        # This row's Role is the synthetic "Admin,Developer" string, so before the fix
+        # the rule fired and the SAME array asserted both "the check could not run"
+        # (marker) and its verdict (real finding) -- a self-contradiction, and the real
+        # finding reached the privilege-creep CSV as an uncaveated entitlement finding
+        # because markers are filtered out of that export. Suppressed, the marker is the
+        # only output and its claim is true.
+        real_creep = [f for f in findings["privilege_creep"] if f.get("status") != "incomplete_data"]  # FIX: C6-RT-19
+        assert real_creep == [], real_creep  # FIX: C6-RT-19
 
     def test_run_access_review_azure_is_not_false_clean(self, monkeypatch):
         """End-to-end azure path: counts honest, compliance 'incomplete' — never false-clean."""
@@ -432,28 +489,112 @@ class TestAccessReviewIncompleteData:
         result = run_access_review(provider="azure-ad", days_threshold=90)
         summary = result["summary"]
         # incomplete_data is surfaced; markers do NOT inflate real-finding counts.
-        assert summary["incomplete_data_count"] == 2
-        assert summary["privilege_creep_count"] == 1     # admin+dev real finding only
+        assert summary["incomplete_data_count"] == 3  # FIX: C6-RT-19: +admin_developer_combo
+        # FIX: C6-RT-19: zero, because no privilege-creep sub-rule can run on this source.
+        # A bare zero here was the original defect; what makes it honest is that it is
+        # reported ALONGSIDE incomplete_data_count 3 and iso27001_a9_2_5 "incomplete",
+        # so the zero cannot be read as "entitlements reviewed, none found".
+        assert summary["privilege_creep_count"] == 0  # FIX: C6-RT-19
         assert summary["orphaned_approver_count"] == 0    # marker excluded from the real count
         # The core fix: privilege-creep compliance is NOT reported clean when data is missing.
         assert result["compliance"]["iso27001_a9_2_5"] == "incomplete"
+        # FIX: C6-RT-19: and the qualifier naming Role is actually present in the payload.
+        creep = result["findings"]["privilege_creep"]  # FIX: C6-RT-19
+        assert any(  # FIX: C6-RT-19
+            m.get("check") == "admin_developer_combo" and m["missing_fields"] == ["Role"]  # FIX: C6-RT-19
+            for m in creep  # FIX: C6-RT-19
+        ), creep  # FIX: C6-RT-19
 
-    def test_azure_privilege_creep_csv_export_excludes_markers(self, monkeypatch, tmp_path):
-        """The --output-privilege-creep-csv artifact must not serialize the incomplete_data marker."""
-        monkeypatch.setattr(scan_access_mod, "load_azure_ad", lambda **kw: self._azure_rows())
-        creep_csv = tmp_path / "creep.csv"
-        run_access_review(
+    def test_azure_privilege_creep_csv_is_not_written_when_entitlements_unreviewed(
+        self, monkeypatch, tmp_path
+    ):  # FIX: C6-RT-19
+        """azure-ad produces no privilege-creep CSV, because no sub-rule could run.
+
+        FIX: C6-RT-19.  Before the fix this artifact was written and contained a
+        jobTitle-derived row presented as an entitlement finding.  The absence of the
+        file is deliberately NOT the only signal -- the JSON result still carries the
+        marker naming Role, so a consumer has something positive to read.
+        """
+        monkeypatch.setattr(scan_access_mod, "load_azure_ad", lambda **kw: self._azure_rows())  # FIX: C6-RT-19
+        creep_csv = tmp_path / "creep.csv"  # FIX: C6-RT-19
+        result = run_access_review(  # FIX: C6-RT-19
             provider="azure-ad",
             days_threshold=90,
             output_privilege_creep_csv=str(creep_csv),
         )
-        assert creep_csv.exists()
-        lines = [ln for ln in creep_csv.read_text(encoding="utf-8").splitlines() if ln.strip()]
-        # Header + exactly one real finding (az1 admin+dev); no empty-identity marker row.
-        assert len(lines) == 2, lines
-        assert "az1" in lines[1]
-        assert "incomplete_data" not in creep_csv.read_text(encoding="utf-8")
-        assert "could not run" not in creep_csv.read_text(encoding="utf-8")
+        assert not creep_csv.exists()  # FIX: C6-RT-19
+        markers = [  # FIX: C6-RT-19
+            m for m in result["findings"]["privilege_creep"]  # FIX: C6-RT-19
+            if m.get("status") == "incomplete_data"  # FIX: C6-RT-19
+        ]  # FIX: C6-RT-19
+        assert {m["check"] for m in markers} == {  # FIX: C6-RT-19
+            "production_access_in_non_prod_role",  # FIX: C6-RT-19
+            "admin_developer_combo",  # FIX: C6-RT-19
+        }  # FIX: C6-RT-19
+        assert result["compliance"]["iso27001_a9_2_5"] == "incomplete"  # FIX: C6-RT-19
+
+    def test_marker_rows_never_serialize_into_privilege_creep_csv(
+        self, monkeypatch, tmp_path, sample_access_rows
+    ):  # FIX: C6-RT-19
+        """A written privilege-creep CSV contains real findings only, never a marker row.
+
+        FIX: C6-RT-19 -- retargeted from the azure-ad path, which can no longer produce
+        a real privilege-creep finding.  This keeps C6-RT-08's real-finding-vs-marker
+        export separation covered end to end on a source that still emits both.
+        """
+        monkeypatch.setattr(scan_access_mod, "load_csv", lambda _p: sample_access_rows)  # FIX: C6-RT-19
+        creep_csv = tmp_path / "creep.csv"  # FIX: C6-RT-19
+        run_access_review(  # FIX: C6-RT-19
+            input_csv="dummy.csv", days_threshold=90, output_privilege_creep_csv=str(creep_csv)
+        )
+        text = creep_csv.read_text(encoding="utf-8")  # FIX: C6-RT-19
+        lines = [ln for ln in text.splitlines() if ln.strip()]  # FIX: C6-RT-19
+        assert len(lines) == 3, lines  # header + the 2 real CSV-path findings
+        assert "incomplete_data" not in text  # FIX: C6-RT-19
+        assert "could not run" not in text  # FIX: C6-RT-19
+
+    def test_real_finding_and_marker_coexist_and_stay_separated(self, sample_access_rows):  # FIX: C6-RT-19
+        """When Role IS trustworthy but other fields are not, both kinds are emitted.
+
+        FIX: C6-RT-19.  The azure-ad path now suppresses every Role-derived finding, so
+        it can no longer exercise C6-RT-08's separation logic.  This pins that logic
+        directly: a source declaring Systems/GrantedBy unavailable -- but NOT Role --
+        must still emit the real admin+developer finding alongside the two markers.
+        """
+        findings = analyze_access(  # FIX: C6-RT-19
+            sample_access_rows,
+            days_threshold=90,
+            unavailable_fields=frozenset({"Systems", "GrantedBy"}),  # FIX: C6-RT-19
+        )
+        creep = findings["privilege_creep"]  # FIX: C6-RT-19
+        real = [f for f in creep if f.get("status") != "incomplete_data"]  # FIX: C6-RT-19
+        markers = [f for f in creep if f.get("status") == "incomplete_data"]  # FIX: C6-RT-19
+        assert any("admin" in " ".join(f.get("roles", [])).lower() for f in real), real  # FIX: C6-RT-19
+        assert [m["check"] for m in markers] == ["production_access_in_non_prod_role"]  # FIX: C6-RT-19
+        # Real findings carry identity; markers never do.
+        assert all("user_id" in f for f in real)  # FIX: C6-RT-19
+        assert all("user_id" not in m for m in markers)  # FIX: C6-RT-19
+
+    @pytest.mark.parametrize("bogus", ["Azure-AD", "azure_ad", "AZURE-AD", "okta"])  # FIX: C6-RT-19
+    def test_unrecognised_provider_fails_closed(self, monkeypatch, bogus):  # FIX: C6-RT-19
+        """An unknown provider must raise, never silently report a clean review.
+
+        FIX: C6-RT-19.  The loader used a catch-all ``else:`` (any non-CSV provider got
+        load_azure_ad) while ``unavailable_fields`` was gated on an exact
+        ``input_source == "azure-ad"`` match.  A caller passing "Azure-AD" therefore
+        pulled REAL Microsoft Graph data and reported zero incomplete_data markers with
+        iso27001_a9_2_5 "pass" -- textbook false-clean evidence.  The two decisions are
+        now made in one branch, and anything unrecognised fails closed.
+        """
+        called = []  # FIX: C6-RT-19
+        monkeypatch.setattr(  # FIX: C6-RT-19
+            scan_access_mod, "load_azure_ad",  # FIX: C6-RT-19
+            lambda **kw: called.append(kw) or self._azure_rows(),  # FIX: C6-RT-19
+        )  # FIX: C6-RT-19
+        with pytest.raises(ValueError, match="Unsupported provider"):  # FIX: C6-RT-19
+            run_access_review(provider=bogus, days_threshold=90)  # FIX: C6-RT-19
+        # It must refuse BEFORE querying the provider, not after.
+        assert called == []  # FIX: C6-RT-19
 
     def test_run_access_review_csv_summary_is_additive(self, monkeypatch, sample_access_rows):
         """CSV path: new incomplete_data_count==0; compliance values unchanged (warn/pass)."""
@@ -467,6 +608,101 @@ class TestAccessReviewIncompleteData:
         # No "incomplete" status on the CSV path; existing warn/pass semantics preserved.
         assert result["compliance"]["iso27001_a9_2_5"] == "warn"
         assert result["compliance"]["soc2_cc6_1"] == "warn"
+
+    # -----------------------------------------------------------------------
+    # C6-RT-19: AZURE_AD_UNAVAILABLE_FIELDS must not be an unverified claim of
+    # its own. These tests pin the constant to what load_azure_ad() really
+    # emits, and prove the role sub-rule cannot produce clean evidence.
+    # -----------------------------------------------------------------------
+
+    def test_load_azure_ad_row_schema_matches_unavailable_fields_claim(self, monkeypatch):
+        """The constant is grounded: patch Graph, inspect the row load_azure_ad emits.
+
+        The assertion differs per listed field, which is the whole point:
+          Systems / GrantedBy -> literally "" (absent from the query).
+          Role                -> POPULATED, with the user's jobTitle (wrong meaning).
+        """  # FIX: C6-RT-19
+        fake_page = {  # FIX: C6-RT-19: one Graph user page, no nextLink
+            "value": [
+                {
+                    "id": "az-guid-1",
+                    "displayName": "Dana Real",
+                    "userPrincipalName": "dana@corp.com",
+                    "jobTitle": "Security Analyst",   # FIX: C6-RT-19: HR metadata
+                    "signInActivity": {"lastSignInDateTime": "2026-08-01T09:00:00Z"},
+                    "createdDateTime": "2024-03-01T00:00:00Z",
+                }
+            ]
+        }
+        # @read_only_io only rejects a Flask GET context (it is a no-op otherwise) and
+        # load_azure_ad resolves _graph_token/_graph_get from module globals at call
+        # time, so patching the module attributes reaches the real code path.
+        monkeypatch.setattr(scan_access_mod, "_graph_token", lambda *a, **k: "fake-token")  # FIX: C6-RT-19
+        monkeypatch.setattr(scan_access_mod, "_graph_get", lambda endpoint, token: fake_page)  # FIX: C6-RT-19
+
+        rows = scan_access_mod.load_azure_ad(
+            tenant_id="t", client_id="c", client_secret="s",
+        )  # FIX: C6-RT-19
+        assert len(rows) == 1
+        row = rows[0]
+
+        # Case 1 — absent fields come out as the empty string.
+        assert row["Systems"] == ""    # FIX: C6-RT-19
+        assert row["GrantedBy"] == ""  # FIX: C6-RT-19
+        # Case 2 — Role is NOT empty; it is the jobTitle verbatim. This is exactly
+        # why it needs a marker: a populated column that answers the wrong question.
+        assert row["Role"] == "Security Analyst"  # FIX: C6-RT-19
+        assert row["Role"] == fake_page["value"][0]["jobTitle"]  # FIX: C6-RT-19
+
+        # Every field the constant names is unusable for its check, for one of
+        # the two reasons above — nothing else is listed.
+        assert scan_access_mod.AZURE_AD_UNAVAILABLE_FIELDS == frozenset(
+            {"Systems", "GrantedBy", "Role"}
+        )  # FIX: C6-RT-19
+        # The Role value the provider emits cannot satisfy the entitlement test.
+        derived = {r.strip().lower() for r in row["Role"].split(",") if r.strip()}  # FIX: C6-RT-19
+        assert not ("admin" in derived and "developer" in derived)  # FIX: C6-RT-19
+
+    def test_jobtitle_role_is_not_reported_as_bare_zero_privilege_creep(self):
+        """A jobTitle-derived Role must never yield privilege_creep 0 with no marker."""  # FIX: C6-RT-19
+        findings = analyze_access(  # FIX: C6-RT-19
+            self._azure_rows_provider_realistic(),
+            days_threshold=90,
+            unavailable_fields=scan_access_mod.AZURE_AD_UNAVAILABLE_FIELDS,
+        )
+        real_creep = [f for f in findings["privilege_creep"] if f.get("status") != "incomplete_data"]
+        markers = [f for f in findings["privilege_creep"] if f.get("status") == "incomplete_data"]
+        # Real jobTitles fire no sub-rule at all...
+        assert real_creep == []  # FIX: C6-RT-19
+        # ...so the zero MUST be accompanied by markers explaining why it is not clean.
+        assert {m["check"] for m in markers} == {  # FIX: C6-RT-19
+            "admin_developer_combo",
+            "production_access_in_non_prod_role",
+        }
+
+    def test_jobtitle_role_forces_incomplete_compliance_end_to_end(self, monkeypatch):
+        """Even with zero real findings, azure-ad must not report A.9.2.5 pass."""  # FIX: C6-RT-19
+        monkeypatch.setattr(
+            scan_access_mod, "load_azure_ad", lambda **kw: self._azure_rows_provider_realistic()
+        )  # FIX: C6-RT-19
+        result = run_access_review(provider="azure-ad", days_threshold=90)
+        summary = result["summary"]
+        assert summary["privilege_creep_count"] == 0        # FIX: C6-RT-19
+        assert summary["incomplete_data_count"] == 3        # FIX: C6-RT-19
+        # A bare zero would be false-clean evidence; the compliance signal says otherwise.
+        assert result["compliance"]["iso27001_a9_2_5"] == "incomplete"  # FIX: C6-RT-19
+
+    def test_role_alone_unavailable_still_forces_incomplete_compliance(self, monkeypatch):
+        """Role is independently load-bearing for A.9.2.5, not covered by Systems/GrantedBy."""  # FIX: C6-RT-19
+        monkeypatch.setattr(
+            scan_access_mod, "AZURE_AD_UNAVAILABLE_FIELDS", frozenset({"Role"})
+        )  # FIX: C6-RT-19: hypothetical future source where only Role is untrustworthy
+        monkeypatch.setattr(
+            scan_access_mod, "load_azure_ad", lambda **kw: self._azure_rows_provider_realistic()
+        )  # FIX: C6-RT-19
+        result = run_access_review(provider="azure-ad", days_threshold=90)
+        assert result["summary"]["incomplete_data_count"] == 1  # FIX: C6-RT-19
+        assert result["compliance"]["iso27001_a9_2_5"] == "incomplete"  # FIX: C6-RT-19
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #138

> **Stacked on #136.** Base is `fix/c6-rt-08-azure-incomplete-data` because this depends on `AZURE_AD_UNAVAILABLE_FIELDS` and the `unavailable_fields` parameter, which are not on `main`. **Retarget this PR to `main` after #136 merges and before deleting its branch.**

`load_azure_ad` populates the entitlement-shaped `Role` column from the Microsoft Graph `jobTitle` attribute — free-text HR metadata. Real Azure AD entitlements live in `/directoryRoles`, `appRoleAssignments` and group memberships, none of which are queried. `analyze_access` then derived entitlements by comma-splitting that string, so the Admin+Developer sub-rule was inert on azure-ad while still reporting a numeric zero that read as a trustworthy "no privilege creep found". A user holding Global Administrator plus developer app-role assignments, with `jobTitle` "Security Analyst", yielded `roles == {"security analyst"}` and `privilege_creep_count == 0`.

Implements the ratified **Option A**. Option B (querying real entitlements) is deliberately not done here: it needs `RoleManagement.Read.Directory` / `Directory.Read.All`, a permissions change rather than a fix. No Graph scope or query was added; the `$select` string is unchanged.

### Changes
- `Role` joins `AZURE_AD_UNAVAILABLE_FIELDS`, and `analyze_access` emits a C6-RT-08-shaped marker naming check `admin_developer_combo` and `missing_fields ["Role"]`. The constant's comment and both docstrings now define "unavailable" as *"the source cannot supply a trustworthy value for this column's access-review semantics"*, distinguishing the literally-absent fields (`Systems`, `GrantedBy`) from the populated-but-semantically-wrong one (`Role`) — so the fix does not mint a second false claim.
- `Role` joins the `iso27001_a9_2_5` gate set. A.9.2.5 reviews entitlements and each field is independently load-bearing: if `Systems` and `GrantedBy` ever became available, a jobTitle-derived `Role` must still force `"incomplete"`.
- **Both privilege-creep sub-rules are suppressed when `Role` is not entitlement data.** Previously the rule still fired, so a `jobTitle` reading "Admin, Developer" put a claim and its own contradiction in the same array — a marker saying the check could not run beside the check's verdict — and, because markers are filtered out of the privilege-creep CSV export, that finding reached the artifact as an uncaveated entitlement finding.
- `run_access_review` now chooses the loader and declares its unavailable fields in **one** branch. The loader was a catch-all `else:` while `unavailable_fields` was gated on an exact `input_source == "azure-ad"` match, so `provider="Azure-AD"` or `"azure_ad"` pulled real Graph data and reported zero markers with `iso27001_a9_2_5: "pass"` — the same false-clean class this finding exists to remove. An unrecognised provider now fails closed, before any provider query.

### Tests
The `_azure_rows()` fixture is relabelled as synthetic and not-provider-representative for `Role`. A schema-pin test patches `_graph_token` / `_graph_get` with a fake Graph page and asserts `Systems`/`GrantedBy` emit as literal `""` while `Role` emits **populated** with the jobTitle — so the constant is no longer an unverified claim of its own. The C6-RT-08 export-separation coverage that the azure path can no longer exercise is retargeted to a source that still emits a real finding and a marker together, rather than deleted.

### Verification
CSV input path proven **byte-identical** to this branch's parent across findings, summary and compliance, with zero markers. Full suite **448 passed / 3 skipped** against the 438/3 parent baseline — exactly the 10 new cases, no regressions.