### PR TITLE
fix(C6-RT-25): restore_skill attributes a swapped parent symlink to parent_symlink, not tamper

### DIFF
--- a/scripts/supply-chain/skill_integrity_monitor.sh
+++ b/scripts/supply-chain/skill_integrity_monitor.sh
@@ -831,9 +831,18 @@ restore_skill() {
         # Tamper detection: QUARANTINE_INFO.txt must agree with the recorded origin. Compare ## FIX: C6-M-17
         # canonically (-m: the original location no longer exists once the skill was moved). ## FIX: C6-M-17
         if [ -n "$info_path" ]; then ## FIX: C6-M-17
-            local canon_info ## FIX: C6-M-17
+            local canon_info canon_authoritative ## FIX: C6-RT-25
             canon_info=$(canonicalize_path "$info_path" 2>/dev/null || echo "$info_path") ## FIX: C6-M-17
-            if [ "$canon_info" != "$authoritative" ]; then ## FIX: C6-M-17
+            # C6-RT-25: canonicalize BOTH sides. Comparing a resolved path against the raw
+            # ledger string answered the wrong question: any symlink component in the recorded
+            # origin -- swapped in by an attacker, or a legitimate symlinked mount -- made the
+            # two differ and reported reason=tamper even when QUARANTINE_INFO.txt agreed with
+            # the ledger byte-for-byte. That misattributed a parent-symlink swap to metadata
+            # tampering and made the parent_symlink guard below unreachable in the very case it
+            # exists for. The question this check must answer is "do the info file and the
+            # ledger name the same origin", which is only answerable in a shared normal form.
+            canon_authoritative=$(canonicalize_path "$authoritative" 2>/dev/null || echo "$authoritative") ## FIX: C6-RT-25
+            if [ "$canon_info" != "$canon_authoritative" ]; then ## FIX: C6-RT-25
                 error "Refusing restore: QUARANTINE_INFO.txt path ($info_path) disagrees with recorded origin ($authoritative) — possible tampering" ## FIX: C6-M-17
                 audit "RESTORE_REJECTED" "Skill: $quarantine_id | reason=tamper | info=$info_path | recorded=$authoritative" ## FIX: C6-M-17
                 return 1 ## FIX: C6-M-17


### PR DESCRIPTION
Closes #148
Unblocks #140 / #144.

The tamper check compared a **canonicalized** path against a **raw** one:

```bash
canon_info=$(canonicalize_path "$info_path" ...)
if [ "$canon_info" != "$authoritative" ]; then   # $authoritative NOT canonicalized
```

`canonicalize_path` is `realpath -m`, so the left side had symlinks resolved and the right side did not. Whenever the recorded origin contained any symlink component that resolved elsewhere, the two differed and the restore was rejected as `reason=tamper` — even though `QUARANTINE_INFO.txt` agreed with the ledger byte-for-byte. The CI audit line showed `info=` and `recorded=` as *identical strings* while still reporting tamper.

### The security property was never at risk
`RC=1`, `EVIL=clean`, nothing escapes the recorded root. Two real defects followed anyway:

- **Misattribution.** An operator reading `reason=tamper` investigates edited quarantine metadata — an insider touching `QUARANTINE_INFO.txt` — when the actual event was a filesystem symlink swap. Different attacker, different response. Same class as C6-RT-11 (#137).
- **The `parent_symlink` guard was unreachable** in the exact scenario it was written for, because the tamper check always fired first.

There was also a latent false-rejection in benign deployments: any legitimately symlinked path component — a symlinked mount, or macOS where `/tmp` → `/private/tmp` — made *every* tracked restore fail as suspected tampering. Fails closed, so safe rather than dangerous, but it cries wolf.

### The fix does not weaken the control
Canonicalizing both sides makes the comparison answer the question the check is actually asking — *do the info file and the ledger name the same origin* — which is only answerable in a shared normal form. An attacker who edits `QUARANTINE_INFO.txt` to a path that canonicalizes to the recorded origin's canonical form has named the same destination, and the `mv` still uses `target=$authoritative`, which the `parent_symlink` guard then validates.

### Verification
Linux, via the combined verification run in #149 — this test is `skipif`-guarded on Windows, so this is its **first-ever execution anywhere**:

```
tests/integration/test_skill_restore_origin.py::test_symlink_swapped_parent_is_rejected PASSED
junit summary: ran=136 failures=0 errors=0 skipped=0
GATE PASS: 136 test(s) ran, 0 skipped, 0 failed.
```

Windows: 7 passed, 1 skipped — the genuine-tamper case still rejects with `reason=tamper`. `bash -n` clean; `shellcheck -S warning -x` runs in the `lint` job.