### PR TITLE
fix(C6-RT-23): read_only_io now actually rejects a GET context instead of catching its own exception

### DIFF
--- a/.github/workflows/compliance-check.yml
+++ b/.github/workflows/compliance-check.yml
@@ -99,7 +99,9 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install -e .
+          # FIX: C6-RT-23: [test] brings flask, so the @read_only_io GET-guard tests
+          # exercise a real Flask request context instead of importorskip-ing away.
+          pip install -e ".[test]"
           pip install pytest pytest-cov
 
       - name: Run policy compliance tests
@@ -109,6 +111,13 @@ jobs:
       - name: Run vulnerability scanning tests
         run: |
           pytest tests/security/test_vulnerability_scanning.py --junit-xml=test-results-vuln.xml -v
+
+      # FIX: C6-RT-23: this file was run by NO workflow, which is why a security control
+      # that never fired went unnoticed for a whole cycle. -rs prints the reason for any
+      # skip, so a skipped guard test can never again read as a pass.
+      - name: Run read-only I/O guard tests # FIX: C6-RT-23
+        run: |
+          pytest tests/security/test_scan_access_security.py --junit-xml=test-results-readonly-io.xml -v -rs
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,13 @@ dependencies = [
 [project.optional-dependencies]  # FIX: C6-RT-07
 # PDF rendering for `openclaw-cli report weekly --pdf` (lazy-imported in src/clawdbot/report_weekly.py)
 reporting = ["reportlab>=4.0"]  # FIX: C6-RT-07
+# Test-only. flask is required to exercise the @read_only_io GET guard against a REAL
+# Flask request context. Deliberately NOT a runtime dependency: this is a security
+# playbook, not a web app, and the decorator lazy-imports flask inside its wrapper.
+# Without this extra the two real-Flask tests importorskip away on every machine, which
+# is one of the three reasons C6-RT-23 (a security control that was a no-op) survived an
+# entire audit cycle unnoticed. Installed by the compliance-check security-tests job.
+test = ["flask>=3.0"]  # FIX: C6-RT-23
 
 [project.scripts]
 openclaw-cli = "clawdbot.openclaw_cli:main"

--- a/src/clawdbot/config.py
+++ b/src/clawdbot/config.py
@@ -47,19 +47,30 @@ def read_only_io(func: F) -> F:
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         # Check if we are in a Flask HTTP GET context. Raises ReadOnlyIOViolation
         # if so. FastAPI detection is not implemented — see docstring scope note.
+        #
+        # C6-RT-23: the raise MUST stay outside the try. ReadOnlyIOViolation subclasses
+        # RuntimeError, and this handler catches RuntimeError — so raising inside the try
+        # meant the guard caught its own exception and fell through to the call. The GET
+        # branch was dead code and the whole control was a no-op from C5-H-07 until now.
+        # RuntimeError has to remain caught here because that is what real Flask raises
+        # when `request` is touched outside an active request context, which is not a
+        # violation; so the only safe shape is to decide inside the try and act after it.
+        in_get_context = False  # FIX: C6-RT-23
         try:  # FIX: C5-H-07
             # Flask detection only — FastAPI is explicitly out of scope
             from flask import request as flask_request  # type: ignore[import-untyped]  # FIX: C5-H-07
 
-            if flask_request.method == "GET":  # FIX: C5-H-07
-                raise ReadOnlyIOViolation(
-                    f"Function {func.__name__} performs I/O and cannot be called "
-                    "from an HTTP GET handler (GET must be idempotent and side-effect-free). "
-                    "This is a security violation. Use POST instead."
-                )
+            in_get_context = flask_request.method == "GET"  # FIX: C6-RT-23
         except (ImportError, RuntimeError):  # FIX: C5-H-07
             # Flask not available or not in request context, continue
-            pass
+            in_get_context = False  # FIX: C6-RT-23
+
+        if in_get_context:  # FIX: C6-RT-23
+            raise ReadOnlyIOViolation(
+                f"Function {func.__name__} performs I/O and cannot be called "
+                "from an HTTP GET handler (GET must be idempotent and side-effect-free). "
+                "This is a security violation. Use POST instead."
+            )
 
         return func(*args, **kwargs)  # FIX: C5-H-07
 

--- a/tests/security/test_scan_access_security.py
+++ b/tests/security/test_scan_access_security.py
@@ -6,6 +6,9 @@ that decorators prevent accidental HTTP GET exposure of I/O functions.
 
 from __future__ import annotations
 
+import sys  # FIX: C6-RT-23
+import types  # FIX: C6-RT-23
+
 import pytest
 
 from clawdbot.config import ReadOnlyIOViolation, read_only_io
@@ -120,3 +123,131 @@ def test_read_only_io_preserves_function_metadata() -> None:
     # Test that the function still works correctly
     result = example_function(1, "test")
     assert result == "1: test"
+
+
+# ---------------------------------------------------------------------------
+# C6-RT-23 — the GET guard must actually fire.
+#
+# Until this fix the decorator raised ReadOnlyIOViolation *inside* a
+# `try: ... except (ImportError, RuntimeError): pass`, and ReadOnlyIOViolation
+# subclasses RuntimeError — so the guard caught its own exception and fell through
+# to the wrapped call. The control was a complete no-op from C5-H-07 onward.
+#
+# The two real-Flask tests above are importorskip-guarded, and flask is not a
+# default dependency, so they skipped everywhere and the defect survived an entire
+# audit cycle. These tests stub `flask` in sys.modules instead, so they ALWAYS run
+# regardless of whether flask is installed. They are the ones that must stay green.
+# ---------------------------------------------------------------------------
+
+def _fake_flask(method: str | None = None, raise_runtime_error: bool = False):  # FIX: C6-RT-23
+    """Build a stub `flask` module whose `request.method` behaves as specified.
+
+    ``raise_runtime_error=True`` reproduces real Flask's behaviour when ``request``
+    is touched outside an active request context — it raises RuntimeError, which is
+    NOT a violation and must be swallowed.
+    """
+    module = types.ModuleType("flask")  # FIX: C6-RT-23
+
+    class _Request:  # FIX: C6-RT-23
+        @property
+        def method(self):  # FIX: C6-RT-23
+            if raise_runtime_error:  # FIX: C6-RT-23
+                raise RuntimeError("Working outside of request context")  # FIX: C6-RT-23
+            return method  # FIX: C6-RT-23
+
+    module.request = _Request()  # type: ignore[attr-defined]  # FIX: C6-RT-23
+    return module  # FIX: C6-RT-23
+
+
+def test_get_context_raises_and_does_not_run_the_function(monkeypatch) -> None:  # FIX: C6-RT-23
+    """The whole point: a GET context must raise, and the I/O must not happen."""
+    monkeypatch.setitem(sys.modules, "flask", _fake_flask(method="GET"))  # FIX: C6-RT-23
+    calls = []  # FIX: C6-RT-23
+
+    @read_only_io  # FIX: C6-RT-23
+    def performs_io() -> str:  # FIX: C6-RT-23
+        calls.append(1)  # FIX: C6-RT-23
+        return "I/O EXECUTED"  # FIX: C6-RT-23
+
+    with pytest.raises(ReadOnlyIOViolation) as exc:  # FIX: C6-RT-23
+        performs_io()  # FIX: C6-RT-23
+    # The side effect must be prevented, not merely reported after the fact.
+    assert calls == [], "wrapped function ran despite the GET guard"  # FIX: C6-RT-23
+    assert "performs_io" in str(exc.value)  # FIX: C6-RT-23
+    assert "GET" in str(exc.value)  # FIX: C6-RT-23
+
+
+def test_violation_escapes_despite_being_a_runtime_error(monkeypatch) -> None:  # FIX: C6-RT-23
+    """Pins the exact C6-RT-23 shape: a RuntimeError subclass must still escape.
+
+    `except RuntimeError` has to keep catching real out-of-context errors, so this
+    asserts the violation is not swallowed by the very handler that must remain.
+    """
+    monkeypatch.setitem(sys.modules, "flask", _fake_flask(method="GET"))  # FIX: C6-RT-23
+
+    @read_only_io  # FIX: C6-RT-23
+    def performs_io() -> str:  # FIX: C6-RT-23
+        return "I/O EXECUTED"  # FIX: C6-RT-23
+
+    assert issubclass(ReadOnlyIOViolation, RuntimeError)  # FIX: C6-RT-23
+    with pytest.raises(RuntimeError):  # FIX: C6-RT-23
+        performs_io()  # FIX: C6-RT-23
+
+
+def test_outside_request_context_is_not_a_violation(monkeypatch) -> None:  # FIX: C6-RT-23
+    """Real Flask raises RuntimeError outside a request context — must pass through."""
+    monkeypatch.setitem(  # FIX: C6-RT-23
+        sys.modules, "flask", _fake_flask(raise_runtime_error=True)  # FIX: C6-RT-23
+    )  # FIX: C6-RT-23
+
+    @read_only_io  # FIX: C6-RT-23
+    def performs_io() -> str:  # FIX: C6-RT-23
+        return "ok"  # FIX: C6-RT-23
+
+    assert performs_io() == "ok"  # FIX: C6-RT-23
+
+
+def test_non_get_method_is_not_a_violation(monkeypatch) -> None:  # FIX: C6-RT-23
+    """POST must pass through untouched."""
+    monkeypatch.setitem(sys.modules, "flask", _fake_flask(method="POST"))  # FIX: C6-RT-23
+
+    @read_only_io  # FIX: C6-RT-23
+    def performs_io() -> str:  # FIX: C6-RT-23
+        return "ok"  # FIX: C6-RT-23
+
+    assert performs_io() == "ok"  # FIX: C6-RT-23
+
+
+def test_flask_absent_is_not_a_violation(monkeypatch) -> None:  # FIX: C6-RT-23
+    """No flask installed -> ImportError -> pass through.
+
+    Forced rather than relying on the ambient environment, so this stays meaningful
+    on a machine (or CI job) where flask IS installed. Setting a sys.modules entry to
+    None makes `from flask import ...` raise ImportError.
+    """
+    monkeypatch.setitem(sys.modules, "flask", None)  # FIX: C6-RT-23
+
+    @read_only_io  # FIX: C6-RT-23
+    def performs_io() -> str:  # FIX: C6-RT-23
+        return "ok"  # FIX: C6-RT-23
+
+    assert performs_io() == "ok"  # FIX: C6-RT-23
+
+
+def test_decorated_graph_functions_are_guarded_in_get_context(monkeypatch) -> None:  # FIX: C6-RT-23
+    """The guard reaches the real decorated I/O functions, not just local test stubs.
+
+    `load_azure_ad` would otherwise raise ValueError for missing credentials; the
+    ReadOnlyIOViolation must win, proving the guard runs before the function body.
+    """
+    monkeypatch.setitem(sys.modules, "flask", _fake_flask(method="GET"))  # FIX: C6-RT-23
+    monkeypatch.delenv("AZURE_AD_TENANT_ID", raising=False)  # FIX: C6-RT-23
+    monkeypatch.delenv("AZURE_AD_CLIENT_ID", raising=False)  # FIX: C6-RT-23
+    monkeypatch.delenv("AZURE_AD_CLIENT_SECRET", raising=False)  # FIX: C6-RT-23
+
+    with pytest.raises(ReadOnlyIOViolation):  # FIX: C6-RT-23
+        load_azure_ad()  # FIX: C6-RT-23
+    with pytest.raises(ReadOnlyIOViolation):  # FIX: C6-RT-23
+        _graph_token("t", "c", "s")  # FIX: C6-RT-23
+    with pytest.raises(ReadOnlyIOViolation):  # FIX: C6-RT-23
+        _graph_get("https://graph.microsoft.com/v1.0/users", "token")  # FIX: C6-RT-23


### PR DESCRIPTION
Closes #142

`ReadOnlyIOViolation` subclasses `RuntimeError`, and the decorator raised it **inside** a `try: ... except (ImportError, RuntimeError): pass`. The guard caught its own exception and fell through to `return func(*args, **kwargs)`. The GET-rejection branch was dead code — `@read_only_io` has been a **complete no-op since C5-H-07**, while `scan_access.py` and `scan_vulnerability.py` both document it as the control enforcing the GET prohibition for 10 I/O functions.

### The fix
Ratified **Option A**: decide inside the `try`, act after it. `RuntimeError` must stay caught, because that is what real Flask raises when `request` is touched outside an active request context and that is *not* a violation — so the only safe shape is to compute the condition in the `try` and raise outside it. The exception hierarchy is unchanged, so `test_read_only_io_violation_is_runtime_error` still holds.

### Three independent reasons this survived a whole audit cycle — all now closed
1. **The guard was a no-op.**
2. **The regression test that catches it never ran.** `test_read_only_io_raises_on_flask_get` is `importorskip("flask")`-guarded, and flask was in neither `requirements.txt` nor `pyproject.toml`. `pyproject` now carries a `test` extra with flask — deliberately an *extra*, not a runtime dependency: this is a security playbook, not a web app, and the decorator lazy-imports flask inside its wrapper.
3. **The file was run by no CI workflow at all.** compliance-check's `security-tests` job now installs `.[test]` and runs it with `-rs`, so a skipped guard test can never again read as a pass.

### Coverage that does not depend on flask
Six new tests stub `flask` in `sys.modules`, so they run regardless of whether flask is installed — **they**, not the `importorskip`'d pair, are the load-bearing coverage. They pin every branch:

| Scenario | Expected |
|---|---|
| GET context | raises, **and the wrapped function does not execute** |
| violation is a `RuntimeError` subclass | still escapes the handler that must keep catching `RuntimeError` |
| `request.method` raises `RuntimeError` (out of context) | passes through |
| POST | passes through |
| flask absent (`ImportError`) | passes through |
| real `_graph_token` / `_graph_get` / `load_azure_ad` in GET | raises before the body runs |

### Mutation check
Neutering the guard to `in_get_context = False` turns **3 of the new tests red**, including `load_azure_ad` falling through to its credentials `ValueError` — which is exactly what "the guard runs before the body" looks like when it doesn't.

### Verification
Full suite **488 passed / 5 skipped** against a 482/5 baseline on `main` — exactly the six new tests. `actionlint` exit 0; no new `yamllint` findings.

### Scope note
`pyproject.toml` and `.github/workflows/compliance-check.yml` go beyond the two files named in #142, which asked for exactly these to be *proposed explicitly rather than folded in silently*. Without them the fix is real but unproven in CI — the failure mode this cycle exists to end. **This PR's own Compliance Check run is the proof:** it is the first time `test_scan_access_security.py` has ever executed in CI, with flask present so the real-Flask tests run rather than skip.

### Not folded in — candidate finding
Seven other files under `tests/security/` are still run by no CI pytest step (`test_evasion_hardening.py`, `test_verify_hash_chain.py`, `test_security_defaults_hook.py`, `test_malicious_skill_chain_exercise.py`, `test_evidence_snapshot_cli.py`, `test_policy_validator_claims.py`, `test_scan_access_security.py` — the last of which this PR fixes). Running the whole directory would restore trigger/target symmetry with the `tests/security/**` filter added by C6-RT-22, but given C6-RT-21 surfaced 8 pre-existing failures the moment a directory was switched on, that belongs in its own finding rather than in this one.