### PR TITLE
fix(C6-RT-26): compliance-check runs every tests/security file, not three of eleven

### DIFF
--- a/.github/workflows/compliance-check.yml
+++ b/.github/workflows/compliance-check.yml
@@ -104,20 +104,88 @@ jobs:
           pip install -e ".[test]"
           pip install pytest pytest-cov
 
-      - name: Run policy compliance tests
+      # FIX: C6-RT-26: run the WHOLE directory. This replaces three per-file steps that
+      # covered 3 of the 11 files in tests/security/ while this workflow's trigger is
+      # `tests/security/**` -- so a PR editing one of the other eight turned the job
+      # green WITHOUT running the edited test, actively asserting coverage that never
+      # happened. Enumerating files here guarantees every new security test defaults to
+      # unexecuted; naming the directory makes the target match the trigger by
+      # construction. -rs prints the reason for any skip.
+      #
+      # test_detection_replay_validation.py and test_runtime_security_regression.py now
+      # also run in their own workflows. That duplication is deliberate: an --ignore list
+      # to avoid it would recreate the exact target-vs-trigger asymmetry this fixes, and
+      # would rot silently as files are added. Neither needs the `yara` apt package that
+      # detection-replay-validation.yml installs (that suite passes skip_yara=True,
+      # require_yara=False), so this job's dependency set is sufficient.
+      - name: Run security test suite # FIX: C6-RT-26
         run: |
-          pytest tests/security/test_policy_compliance.py --junit-xml=test-results-policy.xml -v
+          pytest tests/security/ --junit-xml=test-results-security.xml -v -rs
 
-      - name: Run vulnerability scanning tests
+      # FIX: C6-RT-26: a green job must mean "the tests ran", not "the tests were
+      # collected" -- same gate shape as integration-tests.yml (C6-RT-21), which caught
+      # 8 pre-existing failures the moment a directory was switched on.
+      - name: Enforce zero-skip / minimum-collected gate # FIX: C6-RT-26
+        if: always()
         run: |
-          pytest tests/security/test_vulnerability_scanning.py --junit-xml=test-results-vuln.xml -v
+          python - <<'PY'
+          import sys
+          import xml.etree.ElementTree as ET
+          from pathlib import Path
 
-      # FIX: C6-RT-23: this file was run by NO workflow, which is why a security control
-      # that never fired went unnoticed for a whole cycle. -rs prints the reason for any
-      # skip, so a skipped guard test can never again read as a pass.
-      - name: Run read-only I/O guard tests # FIX: C6-RT-23
-        run: |
-          pytest tests/security/test_scan_access_security.py --junit-xml=test-results-readonly-io.xml -v -rs
+          # Measured, not guessed: tests/security/ collects 175 on this branch (173 pass
+          # locally plus the 2 flask cases that importorskip away without the `test`
+          # extra, which this job installs). A floor rather than equality so a growing
+          # suite still passes; a suite that silently LOSES tests fails and needs a human
+          # to re-justify the number.
+          EXPECTED_MIN_TESTS = 175
+
+          report = Path("test-results-security.xml")
+          if not report.is_file():
+              print(f"GATE FAIL: {report} was not produced - the test step did not run.")
+              sys.exit(1)
+
+          root = ET.parse(report).getroot()
+          suites = [root] if root.tag == "testsuite" else list(root.iter("testsuite"))
+          total = sum(int(s.get("tests", "0")) for s in suites)
+          errors = sum(int(s.get("errors", "0")) for s in suites)
+          failures = sum(int(s.get("failures", "0")) for s in suites)
+
+          skipped = []
+          for case in root.iter("testcase"):
+              for node in case.findall("skipped"):
+                  name = f"{case.get('classname', '')}::{case.get('name', '')}"
+                  skipped.append((name, (node.get("message") or "").strip()))
+
+          print(
+              f"junit summary: ran={total} failures={failures} "
+              f"errors={errors} skipped={len(skipped)}"
+          )
+
+          ok = True
+          if skipped:
+              print(f"GATE FAIL: {len(skipped)} test(s) SKIPPED; a green job must mean they ran:")
+              for name, reason in skipped:
+                  print(f"  SKIPPED {name}")
+                  print(f"          reason: {reason}")
+              ok = False
+          if total < EXPECTED_MIN_TESTS:
+              print(
+                  f"GATE FAIL: only {total} test(s) ran, expected at least "
+                  f"{EXPECTED_MIN_TESTS} - tests disappeared from collection."
+              )
+              ok = False
+          if errors:
+              print(f"GATE FAIL: {errors} collection/setup error(s) in the junit report.")
+              ok = False
+          if failures:
+              print(f"GATE FAIL: {failures} test failure(s) in the junit report.")
+              ok = False
+
+          if ok:
+              print(f"GATE PASS: {total} test(s) ran, 0 skipped, 0 failed.")
+          sys.exit(0 if ok else 1)
+          PY
 
       - name: Upload test results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Closes #153

The **Run Security Test Suite** job named three files. `tests/security/` contains eleven. Six were executed by no pytest step in any workflow:

`test_evasion_hardening.py` · `test_verify_hash_chain.py` · `test_malicious_skill_chain_exercise.py` · `test_security_defaults_hook.py` · `test_evidence_snapshot_cli.py` · `test_policy_validator_claims.py`

### The mirror image of C6-RT-22
That finding fixed *"the trigger cannot reach the code the job tests"*. Here the trigger says `tests/security/**` but the job ran 3 of the 11 files beneath it. A PR editing one of the other eight **did** trigger Compliance Check, the job **did** go green, and the edited test never ran — worse than not triggering at all, because a green check actively asserts coverage that did not happen.

### CLAUDE.md §5's mandated gate did not exist
§5 requires re-running the evasion fixture suite for any `detections/` change. `test_evasion_hardening.py` **is** that suite, and no workflow ran it. The gate was documented, believed, and absent. The other five guard hash-chain integrity, the malicious-skill chain exercise, `security_defaults_hook.sh`'s enforcement of the §4 immutable defaults, evidence-snapshot CLI behaviour, and policy-validator claim veracity.

**C6-RT-23 (#142) is what leaving one of these uncovered costs:** a security control that was a no-op for a full cycle, whose regression test sat in one of these unrun files.

### Change
Replaces the per-file steps with a single whole-directory run. Enumerating files guarantees every *new* security test defaults to unexecuted; naming the directory makes target match trigger by construction. Adds the junit gate C6-RT-21 established in `integration-tests.yml` — fails on any skip, error, failure, or if the collected count drops below **175**.

The floor is measured, not guessed: `tests/security/` collects 175 (173 pass locally plus the 2 flask cases that `importorskip` away without the `test` extra, which this job installs). A floor rather than equality, so a growing suite passes and a shrinking one fails.

`test_detection_replay_validation.py` and `test_runtime_security_regression.py` now run in two workflows each. Deliberate: an `--ignore` list to avoid the duplication would recreate the exact asymmetry this fixes and would rot silently. Neither needs the `yara` apt package `detection-replay-validation.yml` installs — that suite passes `skip_yara=True, require_yara=False`, verified locally with no yara present.

### Gate proven, not assumed
Extracted **verbatim from this YAML** so the tested code is the shipped code, then driven against real junit output:

| Input | Result |
|---|---|
| real Windows run, 2 flask skips | `GATE FAIL` — both named with reasons |
| zero-skip (expected Linux shape) | `GATE PASS: 175 test(s) ran, 0 skipped, 0 failed` |
| 174 collected | `GATE FAIL` — tests disappeared from collection |
| 3 failures | `GATE FAIL` |
| report missing | `GATE FAIL` — the test step did not run |

### Expectations
Workflow-only diff; no Python touched, so the local suite is unchanged from main's 488 passed / 5 skipped. `actionlint` exit 0; no new `yamllint` findings.

**The six files have never run on a POSIX host.** C6-RT-21 surfaced 8 pre-existing failures the moment a directory was switched on, so the same is plausible here. Nothing will be deselected or relaxed to reach green — anything that fails gets filed as its own finding and fixed first, exactly as #147 and #148 were. This PR's own Compliance Check run is the evidence either way, and the Linux result will be recorded here before merge.

---

## Recorded Linux result — green, first try

[Run 31591104619](https://github.com/topazyo/openclaw-security-playbook/actions/runs/31591104619/job/94096007201):

```
175 passed in 1.77s
junit summary: ran=175 failures=0 errors=0 skipped=0
GATE PASS: 175 test(s) ran, 0 skipped, 0 failed.
```

All eleven files executed, confirmed from the log:

```
test_detection_replay_validation.py   test_evasion_hardening.py
test_evidence_snapshot_cli.py         test_malicious_skill_chain_exercise.py
test_policy_compliance.py             test_policy_validator_claims.py
test_runtime_security_regression.py   test_scan_access_security.py
test_security_defaults_hook.py        test_verify_hash_chain.py
test_vulnerability_scanning.py
```

`skipped=0` also confirms the `.[test]` extra is doing its job — the two flask cases ran rather than `importorskip`-ing away, and `test_security_defaults_hook.py`'s `shutil.which("bash")` guard resolved on the runner.

**Unlike C6-RT-21, no pre-existing Linux failures surfaced.** I said they were plausible and prepared to file them; the six files are simply clean on POSIX. Worth stating explicitly, because "we expected breakage and found none" is a different and weaker claim than "we verified it" — this is the verified one: 61 of these 175 assertions had never executed on a POSIX host before this run.
